### PR TITLE
Shortened message

### DIFF
--- a/components/messaging/ConversationsList.tsx
+++ b/components/messaging/ConversationsList.tsx
@@ -1,17 +1,21 @@
 import TickIcon from '../icons/tickIcon';
 
-import { OpenConversationProps } from './OpenConversation';
+import { message } from '@/utils/supabase/types';
 
-// const cutAfterNCharacters = (text: string, n: number): string => {
-//   return text.length > n ? text.substring(0, n) : text;
-// };
+const cutAfterNCharacters = (text: string, n: number): string => {
+  return text.length > n ? text.substring(0, n) : text;
+};
 
 export type ConversationsListProps = {
   id?: number;
   joined_at: string;
   conversation_id?: number;
   user_id: string;
-  conversations: OpenConversationProps;
+  conversations: {
+    id: number;
+    messages: message[];
+    created_at: string;
+  };
 };
 
 const ConversationsList: React.FC<ConversationsListProps> = ({
@@ -19,14 +23,17 @@ const ConversationsList: React.FC<ConversationsListProps> = ({
   user_id,
   conversations,
 }) => {
-  // const shortenedText = cutAfterNCharacters(lastMessage, 50);
+  const lastMessage =
+    conversations.messages[conversations.messages.length - 1]?.message_text ||
+    'No messages yet';
+  const shortenedText = cutAfterNCharacters(lastMessage, 50);
 
   return (
     <div className='m-2 flex max-h-28 justify-between rounded-lg bg-gray-300 p-4'>
       <div>
         <h2 className='font-bold'>{user_id}</h2>
         <p className='mt-1 overflow-hidden font-light italic'>
-          {conversations.conversation_id} ...
+          {shortenedText} ...
         </p>
       </div>
       <div className='flex flex-col items-end justify-between gap-1 py-2'>

--- a/components/messaging/CoversationStateHandler.tsx
+++ b/components/messaging/CoversationStateHandler.tsx
@@ -29,7 +29,6 @@ const ConversationStateHandler = ({
       ))}
 
       <OpenConversation
-        conversation_id={openConvo.conversation_id as number}
         user_id={openConvo.user_id}
         conversations={openConvo.conversations}
       />

--- a/components/messaging/OpenConversation.tsx
+++ b/components/messaging/OpenConversation.tsx
@@ -4,26 +4,22 @@ import { message } from '@/utils/supabase/types';
 import MessageCard from './MessageCard';
 
 export type OpenConversationProps = {
-  id?: number;
-  joined_at?: string;
-  conversation_id: number;
   user_id: string;
   conversations: {
-    id?: number;
+    id: number;
     messages: message[];
-    created_at?: string;
+    created_at: string;
   };
 };
 
 const OpenConversation: React.FC<OpenConversationProps> = ({
-  conversation_id,
   conversations,
   user_id,
 }) => {
   return (
     <div className='flex w-2/4 flex-col'>
       {conversations?.messages?.map((message: message) => (
-        <div key={`${conversation_id}-${message.created_at}`}>
+        <div key={`${conversations.id}-${message.created_at}`}>
           <MessageCard
             sender_id={message.sender_id}
             created_at={message.created_at}

--- a/components/messaging/OpenConversation.tsx
+++ b/components/messaging/OpenConversation.tsx
@@ -10,7 +10,7 @@ export type OpenConversationProps = {
   user_id: string;
   conversations: {
     id?: number;
-    messages?: message[];
+    messages: message[];
     created_at?: string;
   };
 };


### PR DESCRIPTION
closes #16 

ConversationsList now shows a shortened version of the latest message in that conversation. If no messages have been exchanged it will display "no messages yet..."
![Screenshot 2024-01-26 at 15 25 52](https://github.com/enBloc-org/kindly/assets/114600712/53876a3b-aa30-4cdd-9b18-4f1f9610736e)

In the process I corrected the OpenConversationProps as it was unnecessarily creating a redundancy in our dot notation and causing some false type errors. As a result, OpenConversation now only receives two props - yey for less drilling 🕳️ 🎉 