### PR TITLE
style MessageCard component

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -63,7 +63,3 @@ body {
 .green-border-card {
   @apply rounded-xl border-2 border-solid border-primaryGreen p-4;
 }
-
-.self {
-  @apply float-right;
-}

--- a/app/globals.css
+++ b/app/globals.css
@@ -56,10 +56,18 @@ body {
   @apply overflow-hidden rounded-lg bg-white px-8  pb-5 shadow-sm transition-all hover:scale-95 hover:shadow-lg lg:text-lg;
 }
 
-.message-card__self {
-  @apply relative float-right m-2 min-h-max w-5/6 overflow-hidden rounded-lg bg-white px-8 pb-1 pb-5 pl-3 pr-3 pt-3 text-black shadow-lg shadow-sm transition-all sm:w-96 lg:text-lg;
+.message-card {
+  @apply relative m-2 min-h-max w-5/6 overflow-hidden rounded-lg bg-background px-8 pb-1 pb-5 pl-3 pr-3 pt-3 text-black transition-all sm:w-96 lg:text-lg;
 }
 
-.message-card__other {
-  @apply relative m-2 min-h-max w-5/6 overflow-hidden rounded-lg bg-primaryGreen px-8 pb-1 pb-5 pl-3 pr-3 pt-3 text-black shadow-lg shadow-sm transition-all sm:w-96 lg:text-lg;
+.green-border-card{
+  @apply border-primaryGreen border-solid border-2 rounded-xl p-4
+}
+
+.self {
+  @apply relative float-right;
+}
+
+.other {
+  @apply relative;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -57,17 +57,13 @@ body {
 }
 
 .message-card {
-  @apply relative m-2 min-h-max w-5/6 overflow-hidden rounded-lg bg-background px-8 pb-1 pb-5 pl-3 pr-3 pt-3 text-black transition-all sm:w-96 lg:text-lg;
+  @apply relative min-h-max w-5/6 overflow-hidden rounded-lg bg-background px-4 py-2 text-black transition-all sm:w-96 lg:text-lg;
 }
 
-.green-border-card{
-  @apply border-primaryGreen border-solid border-2 rounded-xl p-4
+.green-border-card {
+  @apply rounded-xl border-2 border-solid border-primaryGreen p-4;
 }
 
 .self {
-  @apply relative float-right;
-}
-
-.other {
-  @apply relative;
+  @apply float-right;
 }

--- a/components/messaging/MessageCard.tsx
+++ b/components/messaging/MessageCard.tsx
@@ -19,21 +19,19 @@ const MessageCard: React.FC<MessageCardProps> = ({
   currentUser,
 }) => {
   const isCurrentUser = sender_id === currentUser;
+  const dateStamp = created_at.slice(0, 10).replaceAll('-', ' ');
 
   return (
-    <div className={`message-card${isCurrentUser ? '__self' : '__other'}`}>
-      <div>
-        <p>{isCurrentUser ? 'me' : sender_id}</p>
-      </div>
-      <div className='m-1'>
-        <p className='m-1'>{message_text}</p>
-      </div>
-      <div
-        className={`flex ${isCurrentUser ? 'justify-between' : 'float-right'}`}
+    <div className={`message-card ${isCurrentUser ? 'self' : ''}`}>
+      <p
+        className={`text-lg text-slate-500 ${isCurrentUser ? 'text-right' : 'text-left'}`}
       >
-        <p className='text-slate-600'>{created_at}</p>
-        {isCurrentUser && <TickIcon read={is_read} />}
+        {dateStamp}
+      </p>
+      <div className='m-1'>
+        <p className='green-border-card m-1'>{message_text}</p>
       </div>
+      <TickIcon read={is_read} />
     </div>
   );
 };

--- a/components/messaging/MessageCard.tsx
+++ b/components/messaging/MessageCard.tsx
@@ -22,16 +22,22 @@ const MessageCard: React.FC<MessageCardProps> = ({
   const dateStamp = created_at.slice(0, 10).replaceAll('-', ' ');
 
   return (
-    <div className={`message-card ${isCurrentUser ? 'self' : ''}`}>
+    <div
+      className={`message-card ${isCurrentUser ? 'float-right' : 'float-left'}`}
+    >
       <p
-        className={`text-lg text-slate-500 ${isCurrentUser ? 'text-right' : 'text-left'}`}
+        className={`text-lg text-slate-500 ${isCurrentUser ? 'mr-2 text-right' : 'ml-2 text-left'}`}
       >
         {dateStamp}
       </p>
-      <div className='m-1'>
-        <p className='green-border-card m-1'>{message_text}</p>
+      <div>
+        <p className='green-border-card'>{message_text}</p>
       </div>
-      <TickIcon read={is_read} />
+      {isCurrentUser && (
+        <div className='relative float-right mr-4'>
+          <TickIcon read={is_read} />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
closes #45 

Edited UI on MessageCard component to match the style guide from the Product Owner.

### CSS changes
Edited the previous `.message-card__self` and `.message-card__other` classes for better readability.
`globals.css` now has`.message-card` and `.green-border-card`.

The class `.green-border-card` can be reused across components in the messaging feature.

### To be revised

- **Date stamp on messages**
The style guidance requires a specific format for dates which is not matched in this PR. The guide asks for `16 February 2024` and the version on this pr shows `2024 02 16`

Updating this could be done in the component via a helper function for this specific purpose but it would be better done in the model where we recover that information probably and I think there is currently work being done with that database call by @nichgalzin ( ? )

It's also worth considering whether we really want the date where it is now or if that area should display a time stamp instead.

- **Read receipts**
We embedded read receipts into our database and down to our props across the functionality but the style guide didn't expect any. I have kept them as before - they display for the messages by the logged user only and are black when `false` and orange when `true`

**False**
![Screenshot 2024-02-16 at 14 25 25](https://github.com/enBloc-org/kindly/assets/114600712/afedb9bc-8128-49cc-ace6-b751c6161d21)

**True**
![Screenshot 2024-02-16 at 14 25 56](https://github.com/enBloc-org/kindly/assets/114600712/db31526d-a2fc-445c-a159-4b4a4b10edae)


### Preview
**Current version**
![Screenshot 2024-02-16 at 14 23 18](https://github.com/enBloc-org/kindly/assets/114600712/6e659aaa-a97d-4200-b074-0ea3e6700cdc)

**Style guide**
<img width="627" alt="Screenshot 2024-02-16 at 14 24 34" src="https://github.com/enBloc-org/kindly/assets/114600712/662137d1-4ce8-4c0e-86f6-a2f472368190">
