### PR TITLE
Delete conversation resolves #8

### DIFF
--- a/components/DeleteConvoButton.tsx
+++ b/components/DeleteConvoButton.tsx
@@ -1,0 +1,26 @@
+'use client';
+import deleteConversation from '@/utils/messaging/deleteConversation';
+
+interface DeleteButtonProps {
+  convoId?: number;
+  title: string;
+}
+
+export default function DeleteConvoButton({
+  convoId,
+  title,
+}: DeleteButtonProps) {
+  // Get id of items you want to delete from database and refresh page
+  if (typeof convoId === 'undefined') {
+    throw new Error('item is undefined');
+  }
+
+  return (
+    <button
+      className='button button-rounded '
+      onClick={() => deleteConversation(convoId)}
+    >
+      {title}
+    </button>
+  );
+}

--- a/components/DeleteConvoModal.tsx
+++ b/components/DeleteConvoModal.tsx
@@ -1,0 +1,45 @@
+'use client';
+import React from 'react';
+import { useState } from 'react';
+import DeleteConvoButton from './DeleteConvoButton';
+
+interface ModalProps {
+  name: string;
+  convoId?: number;
+  message: string;
+}
+
+const DeleteConvoModal = ({ name, convoId, message }: ModalProps) => {
+  const [modal, setModal] = useState(false);
+
+  const toggleModal = () => {
+    setModal(!modal);
+  };
+
+  return (
+    <>
+      {!modal && (
+        <button className='button button-rounded my-2' onClick={toggleModal}>
+          {name}
+        </button>
+      )}
+      {modal && (
+        <div className='modal my-2'>
+          <div className='rounded-t bg-backgroundHighlight p-2'>
+            <h1 className='font-semibold text-primaryOrange'>Warning</h1>
+            <p>{message}</p>
+          </div>
+          <DeleteConvoButton convoId={convoId} title='Confirm' />
+          <button
+            className='button button-rounded mx-2 my-2'
+            onClick={toggleModal}
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default DeleteConvoModal;

--- a/components/messaging/ConversationsList.tsx
+++ b/components/messaging/ConversationsList.tsx
@@ -4,6 +4,7 @@ import { useContext, useEffect } from 'react';
 import useConversation from '../../app/(dashboard)/conversations/useConversation';
 import { createSupabaseClient } from '@/utils/supabase/supabaseClient';
 import { ConversationCardType } from '@/utils/messaging/messagingTypes';
+import DeleteConvoModal from '../DeleteConvoModal';
 
 const ConversationsList: React.FC = () => {
   const { allConversations, setAllConversations, setCurrentConversation } =
@@ -55,6 +56,11 @@ const ConversationsList: React.FC = () => {
               user_id={conversation.user_id}
               conversations={conversation.conversations}
               clickHandler={() => updateOpenConvo(conversation.conversation_id)}
+            />
+            <DeleteConvoModal
+              name='X'
+              convoId={conversation.conversation_id}
+              message='By pressing "confirm" you will delete this conversation'
             />
           </div>
         ))

--- a/components/messaging/ConversationsList.tsx
+++ b/components/messaging/ConversationsList.tsx
@@ -37,6 +37,21 @@ const ConversationsList: React.FC = () => {
           ]);
         }
       )
+      .on(
+        'postgres_changes',
+        {
+          event: 'DELETE',
+          schema: 'public',
+          table: 'user_conversations',
+        },
+        (payload) => {
+          setAllConversations([
+            ...allConversations.filter(
+              (conversation) => conversation.id !== payload.old.id
+            ),
+          ]);
+        }
+      )
       .subscribe();
 
     return () => {

--- a/utils/messaging/deleteConversation.ts
+++ b/utils/messaging/deleteConversation.ts
@@ -1,0 +1,11 @@
+import newClient from '@/config/supabaseclient';
+
+// note for if we are turning row level security back on and this breaks If you use delete() with filters and you have RLS enabled, only rows visible through SELECT policies are deleted. Note that by default no rows are visible, so you need at least one SELECT/ALL policy that makes the rows visible.
+export default async function deleteConversation(convIDtobeDeleted: number) {
+  try {
+    const supabase = newClient();
+    await supabase.from('conversations').delete().eq('id', convIDtobeDeleted);
+  } catch (error) {
+    console.log(error);
+  }
+}


### PR DESCRIPTION
Added a model for deleting a conversation. It is not visible in the code but I updated cascade settings on supabase for the userconvo and messages table. The update makes it so if a conversation row is deleted all rows linked to it by foreign key are also deleted this means the related messages and user conversations should vanish (its worked without side effects in tests so far) After that I added a modal containing a button that deletes runs this function. 
<img width="178" alt="image" src="https://github.com/fac28/kindly/assets/113926900/7c2580bd-dfc6-46a0-abcd-e53bd8e21198">

<img width="670" alt="image" src="https://github.com/fac28/kindly/assets/113926900/e93b3f02-f076-4f62-909b-56fb63ac32f4">

## problem

its worth noting that when this button is clicked nothing visibly happens until page reload. I am surprised because in my head supabase live watching should be re-rendering the conversation list. Maybe someone with more knowledge can let me know why that is not happening