### PR TITLE
Issue58 toggle view

### DIFF
--- a/app/(dashboard)/conversations/page.tsx
+++ b/app/(dashboard)/conversations/page.tsx
@@ -13,7 +13,7 @@ const Conversations = async () => {
   return (
     userId && (
       <ConversationProvider userId={userId}>
-        <ConversationsWrapper></ConversationsWrapper>
+        <ConversationsWrapper />
       </ConversationProvider>
     )
   );

--- a/app/(dashboard)/conversations/page.tsx
+++ b/app/(dashboard)/conversations/page.tsx
@@ -1,9 +1,7 @@
 //Components
-import MeatballIcon from '@/components/icons/MeatballIcon';
-import PlusIcon from '@/components/icons/PlusIcon';
+
 import ConversationProvider from '@/components/messaging/ConversationProvider';
-import ConversationsList from '@/components/messaging/ConversationsList';
-import CurrentConversation from '@/components/messaging/CurrentConversation';
+import ConversationWrapper from '@/components/messaging/ConversationWrapper';
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 
@@ -15,18 +13,7 @@ const Conversations = async () => {
   return (
     userId && (
       <ConversationProvider userId={userId}>
-        <div className='mt-4 flex justify-between px-3 '>
-          <button>
-            <PlusIcon width={45} height={45} />
-          </button>
-          <button>
-            <MeatballIcon width={35} height={35} />
-          </button>
-        </div>
-        <div className='mt-4'>
-          <ConversationsList />
-          <CurrentConversation />
-        </div>
+        <ConversationWrapper />
       </ConversationProvider>
     )
   );

--- a/app/(dashboard)/conversations/page.tsx
+++ b/app/(dashboard)/conversations/page.tsx
@@ -1,7 +1,7 @@
 //Components
 
 import ConversationProvider from '@/components/messaging/ConversationProvider';
-import ConversationWrapper from '@/components/messaging/ConversationWrapper';
+import ConversationsWrapper from '@/components/messaging/ConversationWrapper';
 import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 
@@ -13,7 +13,7 @@ const Conversations = async () => {
   return (
     userId && (
       <ConversationProvider userId={userId}>
-        <ConversationWrapper />
+        <ConversationsWrapper></ConversationsWrapper>
       </ConversationProvider>
     )
   );

--- a/app/(dashboard)/conversations/useConversation.tsx
+++ b/app/(dashboard)/conversations/useConversation.tsx
@@ -13,8 +13,8 @@ type ConversationProviderProps = {
   setCurrentConversation: React.Dispatch<
     React.SetStateAction<ConversationCardType>
   > | null;
-  showConversationList: boolean;
-  setShowConversationList: React.Dispatch<React.SetStateAction<boolean>>;
+  showConversationsList: boolean;
+  setShowConversationsList: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 const defaultContext: ConversationProviderProps = {
@@ -32,8 +32,8 @@ const defaultContext: ConversationProviderProps = {
     },
   },
   setCurrentConversation: () => null,
-  showConversationList: false,
-  setShowConversationList: () => true,
+  showConversationsList: false,
+  setShowConversationsList: () => true,
 };
 
 const useConversation = createContext(defaultContext);

--- a/app/(dashboard)/conversations/useConversation.tsx
+++ b/app/(dashboard)/conversations/useConversation.tsx
@@ -13,6 +13,8 @@ type ConversationProviderProps = {
   setCurrentConversation: React.Dispatch<
     React.SetStateAction<ConversationCardType>
   > | null;
+  showConversationList: boolean;
+  setShowConversationList: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 const defaultContext: ConversationProviderProps = {
@@ -29,6 +31,8 @@ const defaultContext: ConversationProviderProps = {
     },
   },
   setCurrentConversation: () => null,
+  showConversationList: false,
+  setShowConversationList: () => true,
 };
 
 const useConversation = createContext(defaultContext);

--- a/components/messaging/ConversationProvider.tsx
+++ b/components/messaging/ConversationProvider.tsx
@@ -27,6 +27,7 @@ const ConversationProvider = ({
         created_at: new Date().toString(),
       },
     });
+  const [showConversationList, setShowConversationList] = useState(false);
 
   useEffect(() => {
     const fetchConversations = async () => {
@@ -55,6 +56,8 @@ const ConversationProvider = ({
         setAllConversations,
         currentConversation,
         setCurrentConversation,
+        showConversationList,
+        setShowConversationList,
       }}
     >
       {children}

--- a/components/messaging/ConversationProvider.tsx
+++ b/components/messaging/ConversationProvider.tsx
@@ -28,7 +28,7 @@ const ConversationProvider = ({
         created_at: new Date().toString(),
       },
     });
-  const [showConversationList, setShowConversationList] = useState(false);
+  const [showConversationsList, setShowConversationsList] = useState(false);
 
   useEffect(() => {
     const fetchConversations = async () => {
@@ -56,8 +56,8 @@ const ConversationProvider = ({
         setAllConversations,
         currentConversation,
         setCurrentConversation,
-        showConversationList,
-        setShowConversationList,
+        showConversationsList,
+        setShowConversationsList,
       }}
     >
       {children}

--- a/components/messaging/ConversationWrapper.tsx
+++ b/components/messaging/ConversationWrapper.tsx
@@ -6,8 +6,10 @@ import PlusIcon from '../icons/PlusIcon';
 import ConversationsList from './ConversationsList';
 import CurrentConversation from './CurrentConversation';
 import useConversation from '@/app/(dashboard)/conversations/useConversation';
+import useMediaQuery from '../hooks/useMediaQuery';
 
 const ConversationWrapper: React.FC = () => {
+  const isBreakpoint = useMediaQuery(1000);
   const { showConversationList, setShowConversationList } =
     useContext(useConversation);
   return (
@@ -20,16 +22,29 @@ const ConversationWrapper: React.FC = () => {
           <MeatballIcon width={35} height={35} />
         </button>
       </div>
-      <div className='mt-4'>
-        {showConversationList === true ? (
+      {!isBreakpoint && (
+        <div className='mt-4'>
           <ConversationsList />
-        ) : (
           <>
             <button onClick={() => setShowConversationList(true)}>back</button>
             <CurrentConversation />
           </>
-        )}
-      </div>
+        </div>
+      )}
+      {isBreakpoint && (
+        <div className='mt-4'>
+          {showConversationList === true ? (
+            <ConversationsList />
+          ) : (
+            <>
+              <button onClick={() => setShowConversationList(true)}>
+                back
+              </button>
+              <CurrentConversation />
+            </>
+          )}
+        </div>
+      )}
     </>
   );
 };

--- a/components/messaging/ConversationWrapper.tsx
+++ b/components/messaging/ConversationWrapper.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import { useState } from 'react';
+import { useContext } from 'react';
 import MeatballIcon from '../icons/MeatballIcon';
 import PlusIcon from '../icons/PlusIcon';
 import ConversationsList from './ConversationsList';
 import CurrentConversation from './CurrentConversation';
+import useConversation from '@/app/(dashboard)/conversations/useConversation';
 
 const ConversationWrapper: React.FC = () => {
-  const [showConversationsList, setShowConversationsList] = useState(false);
+  const { showConversationList, setShowConversationList } =
+    useContext(useConversation);
   return (
     <>
       <div className='mt-4 flex justify-between px-3 '>
@@ -19,13 +21,11 @@ const ConversationWrapper: React.FC = () => {
         </button>
       </div>
       <div className='mt-4'>
-        {showConversationsList === true ? (
-          <ConversationsList
-            setShowConversationsList={setShowConversationsList}
-          />
+        {showConversationList === true ? (
+          <ConversationsList />
         ) : (
           <>
-            <button onClick={() => setShowConversationsList(true)}>back</button>
+            <button onClick={() => setShowConversationList(true)}>back</button>
             <CurrentConversation />
           </>
         )}

--- a/components/messaging/ConversationWrapper.tsx
+++ b/components/messaging/ConversationWrapper.tsx
@@ -10,7 +10,7 @@ import useMediaQuery from '../hooks/useMediaQuery';
 
 const ConversationWrapper: React.FC = () => {
   const isBreakpoint = useMediaQuery(1000);
-  const { showConversationList, setShowConversationList } =
+  const { showConversationsList, setShowConversationsList } =
     useContext(useConversation);
   return (
     <>
@@ -24,11 +24,11 @@ const ConversationWrapper: React.FC = () => {
       </div>
       {isBreakpoint ? (
         <div className='mt-4'>
-          {showConversationList ? (
+          {showConversationsList ? (
             <ConversationsList />
           ) : (
             <>
-              <button onClick={() => setShowConversationList(true)}>
+              <button onClick={() => setShowConversationsList(true)}>
                 back
               </button>
               <CurrentConversation />

--- a/components/messaging/ConversationWrapper.tsx
+++ b/components/messaging/ConversationWrapper.tsx
@@ -22,17 +22,9 @@ const ConversationWrapper: React.FC = () => {
           <MeatballIcon width={35} height={35} />
         </button>
       </div>
-      {!isBreakpoint && (
+      {isBreakpoint ? (
         <div className='mt-4'>
-          <ConversationsList />
-          <>
-            <CurrentConversation />
-          </>
-        </div>
-      )}
-      {isBreakpoint && (
-        <div className='mt-4'>
-          {showConversationList === true ? (
+          {showConversationList ? (
             <ConversationsList />
           ) : (
             <>
@@ -42,6 +34,11 @@ const ConversationWrapper: React.FC = () => {
               <CurrentConversation />
             </>
           )}
+        </div>
+      ) : (
+        <div className='mt-4'>
+          <ConversationsList />
+          <CurrentConversation />
         </div>
       )}
     </>

--- a/components/messaging/ConversationWrapper.tsx
+++ b/components/messaging/ConversationWrapper.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useContext } from 'react';
+import useConversation from '../../app/(dashboard)/conversations/useConversation';
+import MeatballIcon from '../icons/MeatballIcon';
+import PlusIcon from '../icons/PlusIcon';
+import ConversationsList from './ConversationsList';
+import CurrentConversation from './CurrentConversation';
+
+const ConversationWrapper: React.FC = () => {
+  const { currentConversation } = useContext(useConversation);
+  return (
+    <>
+      <div className='mt-4 flex justify-between px-3 '>
+        <button>
+          <PlusIcon width={45} height={45} />
+        </button>
+        <button>
+          <MeatballIcon width={35} height={35} />
+        </button>
+      </div>
+      <div className='mt-4'>
+        {currentConversation === null ? (
+          <ConversationsList />
+        ) : (
+          <CurrentConversation />
+        )}
+      </div>
+    </>
+  );
+};
+
+export default ConversationWrapper;

--- a/components/messaging/ConversationWrapper.tsx
+++ b/components/messaging/ConversationWrapper.tsx
@@ -1,14 +1,13 @@
 'use client';
 
-import { useContext } from 'react';
-import useConversation from '../../app/(dashboard)/conversations/useConversation';
+import { useState } from 'react';
 import MeatballIcon from '../icons/MeatballIcon';
 import PlusIcon from '../icons/PlusIcon';
 import ConversationsList from './ConversationsList';
 import CurrentConversation from './CurrentConversation';
 
 const ConversationWrapper: React.FC = () => {
-  const { currentConversation } = useContext(useConversation);
+  const [showConversationsList, setShowConversationsList] = useState(false);
   return (
     <>
       <div className='mt-4 flex justify-between px-3 '>
@@ -20,10 +19,15 @@ const ConversationWrapper: React.FC = () => {
         </button>
       </div>
       <div className='mt-4'>
-        {currentConversation === null ? (
-          <ConversationsList />
+        {showConversationsList === true ? (
+          <ConversationsList
+            setShowConversationsList={setShowConversationsList}
+          />
         ) : (
-          <CurrentConversation />
+          <>
+            <button onClick={() => setShowConversationsList(true)}>back</button>
+            <CurrentConversation />
+          </>
         )}
       </div>
     </>

--- a/components/messaging/ConversationWrapper.tsx
+++ b/components/messaging/ConversationWrapper.tsx
@@ -26,7 +26,6 @@ const ConversationWrapper: React.FC = () => {
         <div className='mt-4'>
           <ConversationsList />
           <>
-            <button onClick={() => setShowConversationList(true)}>back</button>
             <CurrentConversation />
           </>
         </div>

--- a/components/messaging/ConversationsList.tsx
+++ b/components/messaging/ConversationsList.tsx
@@ -15,7 +15,6 @@ const ConversationsList: React.FC = () => {
   } = useContext(useConversation);
 
   const updateOpenConvo = async (givenId: number) => {
-    console.log('update conversation');
     setCurrentConversation &&
       setCurrentConversation(
         allConversations?.filter(

--- a/components/messaging/ConversationsList.tsx
+++ b/components/messaging/ConversationsList.tsx
@@ -6,12 +6,17 @@ import { createSupabaseClient } from '@/utils/supabase/supabaseClient';
 import { ConversationCardType } from '@/utils/messaging/messagingTypes';
 import DeleteConvoModal from '../DeleteConvoModal';
 
-const ConversationsList: React.FC = ({ setShowConversationsList }) => {
-  const { allConversations, setAllConversations, setCurrentConversation } =
-    useContext(useConversation);
+const ConversationsList: React.FC = () => {
+  const {
+    allConversations,
+    setAllConversations,
+    setCurrentConversation,
+    setShowConversationList,
+  } = useContext(useConversation);
   const supabase = createSupabaseClient;
 
   const updateOpenConvo = async (givenId: number) => {
+    console.log('update conversation');
     setCurrentConversation &&
       setCurrentConversation(
         allConversations?.filter(
@@ -19,7 +24,7 @@ const ConversationsList: React.FC = ({ setShowConversationsList }) => {
         )[0]
       );
 
-    setShowConversationsList(false);
+    setShowConversationList(false);
   };
 
   useEffect(() => {

--- a/components/messaging/ConversationsList.tsx
+++ b/components/messaging/ConversationsList.tsx
@@ -11,7 +11,7 @@ const ConversationsList: React.FC = () => {
     allConversations,
     setAllConversations,
     setCurrentConversation,
-    setShowConversationList,
+    setShowConversationsList,
   } = useContext(useConversation);
 
   const updateOpenConvo = async (givenId: number) => {
@@ -22,7 +22,7 @@ const ConversationsList: React.FC = () => {
         )[0]
       );
 
-    setShowConversationList(false);
+    setShowConversationsList(false);
   };
 
   useEffect(() => {

--- a/components/messaging/ConversationsList.tsx
+++ b/components/messaging/ConversationsList.tsx
@@ -1,6 +1,6 @@
 'use client';
 import ConversationCard from './ConversationCard';
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect} from 'react';
 import useConversation from '../../app/(dashboard)/conversations/useConversation';
 import { createSupabaseClient } from '@/utils/supabase/supabaseClient';
 import { ConversationCardType } from '@/utils/messaging/messagingTypes';
@@ -19,6 +19,7 @@ const ConversationsList: React.FC = () => {
         )[0]
       );
   };
+
 
   useEffect(() => {
     const channel = supabase

--- a/components/messaging/ConversationsList.tsx
+++ b/components/messaging/ConversationsList.tsx
@@ -1,12 +1,12 @@
 'use client';
 import ConversationCard from './ConversationCard';
-import { useContext, useEffect} from 'react';
+import { useContext, useEffect } from 'react';
 import useConversation from '../../app/(dashboard)/conversations/useConversation';
 import { createSupabaseClient } from '@/utils/supabase/supabaseClient';
 import { ConversationCardType } from '@/utils/messaging/messagingTypes';
 import DeleteConvoModal from '../DeleteConvoModal';
 
-const ConversationsList: React.FC = () => {
+const ConversationsList: React.FC = ({ setShowConversationsList }) => {
   const { allConversations, setAllConversations, setCurrentConversation } =
     useContext(useConversation);
   const supabase = createSupabaseClient;
@@ -18,8 +18,9 @@ const ConversationsList: React.FC = () => {
           (conversations) => conversations.conversation_id === givenId
         )[0]
       );
-  };
 
+    setShowConversationsList(false);
+  };
 
   useEffect(() => {
     const channel = supabase

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -9,8 +9,6 @@ import useConversation from '../../app/(dashboard)/conversations/useConversation
 const CurrentConversation: React.FC = () => {
   const { currentConversation } = useContext(useConversation);
 
-  console.log('conversation: ', currentConversation?.conversations?.messages);
-
   return (
     <div className='flex w-2/4 flex-col'>
       {currentConversation?.conversations?.messages?.map(

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -5,7 +5,6 @@ import MessageCard from './MessageCard';
 import MessageForm from './MessageForm';
 import { useContext, useEffect } from 'react';
 import useConversation from '../../app/(dashboard)/conversations/useConversation';
-import BackButton from '../buttons/BackButton';
 
 const CurrentConversation: React.FC = () => {
   const { allConversations, currentConversation, setCurrentConversation } =
@@ -26,7 +25,6 @@ const CurrentConversation: React.FC = () => {
 
   return (
     <div className='flex flex-col'>
-      <BackButton></BackButton>
       {currentConversation?.conversations?.messages?.map(
         (message: MessageType) => (
           <div

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -10,7 +10,7 @@ const CurrentConversation: React.FC = () => {
   const { currentConversation } = useContext(useConversation);
 
   return (
-    <div className='flex w-2/4 flex-col'>
+    <div className='flex flex-col'>
       {currentConversation?.conversations?.messages?.map(
         (message: MessageType) => (
           <div

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -24,7 +24,7 @@ const CurrentConversation: React.FC = () => {
   }, []);
 
   return (
-    <div className='flex flex-col'>
+    <div className='flex w-2/4 flex-col'>
       {currentConversation?.conversations?.messages?.map(
         (message: MessageType) => (
           <div

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -3,25 +3,13 @@
 import { MessageType } from '@/utils/messaging/messagingTypes';
 import MessageCard from './MessageCard';
 import MessageForm from './MessageForm';
-import { useContext, useEffect } from 'react';
+import { useContext } from 'react';
 import useConversation from '../../app/(dashboard)/conversations/useConversation';
 
 const CurrentConversation: React.FC = () => {
-  const { allConversations, currentConversation, setCurrentConversation } =
-    useContext(useConversation);
+  const { currentConversation } = useContext(useConversation);
 
-  useEffect(() => {
-    const highestId = Math.max(
-      ...allConversations.map((conversation) => conversation.conversation_id)
-    );
-
-    setCurrentConversation &&
-      setCurrentConversation(
-        allConversations?.filter(
-          (conversation) => conversation.conversation_id === highestId
-        )[0]
-      );
-  }, []);
+  console.log('conversation: ', currentConversation?.conversations?.messages);
 
   return (
     <div className='flex w-2/4 flex-col'>

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -5,6 +5,7 @@ import MessageCard from './MessageCard';
 import MessageForm from './MessageForm';
 import { useContext, useEffect } from 'react';
 import useConversation from '../../app/(dashboard)/conversations/useConversation';
+import BackButton from '../buttons/BackButton';
 
 const CurrentConversation: React.FC = () => {
   const { allConversations, currentConversation, setCurrentConversation } =
@@ -25,6 +26,7 @@ const CurrentConversation: React.FC = () => {
 
   return (
     <div className='flex flex-col'>
+      <BackButton></BackButton>
       {currentConversation?.conversations?.messages?.map(
         (message: MessageType) => (
           <div


### PR DESCRIPTION
### ConversationWrapper
- We created a ConversationWrapper component that contains the ConversationsList and CurrentConversation
<img width="871" alt="Screenshot 2024-02-22 at 12 08 09" src="https://github.com/enBloc-org/kindly/assets/114364165/aec6caa9-ec1c-46be-8a8d-98e352963231">

Rendering these directly on the page component is not possible because we need to access state within these component. We could not access the state provided by conversationProvider on the page component because it is not compatible server side.

### State management:
- We have added showConversationList, setShowConversationList to conversation provider
- useConversation (where we define the default context) has been updated accordingly
- The biggest (potentially most controversial change) we made was removing the useEffect from CurrentConversation.tsx. This was updating the currentConversation value but as this is already being done by updateOpenConvo in ConversationsList.tsx it prevented the info fetched from the db being rendered on currentConversation

### Back Button:
- We added a back button to conversationWrapper (we couldn't use the backButton component because this has additional functionality built in that we don't need here)
- This only appears in mobile view
- This will need styling (currently appears as "back")

### Media Queries
- We're using the same library and method that was adopted for the navbar view
- Added breakpoint condition to only apply toggle view on mobile devices
<img width="784" alt="Screenshot 2024-02-22 at 12 21 29" src="https://github.com/enBloc-org/kindly/assets/114364165/3a8a7259-3229-4940-8f59-e8906db2b2c9">