### PR TITLE
Issue37 current conversation styling

### DIFF
--- a/components/DeleteConvoButton.tsx
+++ b/components/DeleteConvoButton.tsx
@@ -17,7 +17,7 @@ export default function DeleteConvoButton({
 
   return (
     <button
-      className='button button-rounded '
+      className='button button-rounded'
       onClick={() => deleteConversation(convoId)}
     >
       {title}

--- a/components/DeleteConvoModal.tsx
+++ b/components/DeleteConvoModal.tsx
@@ -17,7 +17,7 @@ const DeleteConvoModal = ({ name, convoId, message }: ModalProps) => {
   };
 
   return (
-    <>
+    <div className='absolute m-3'>
       {!modal && (
         <button className='button button-rounded my-2' onClick={toggleModal}>
           {name}
@@ -30,15 +30,12 @@ const DeleteConvoModal = ({ name, convoId, message }: ModalProps) => {
             <p>{message}</p>
           </div>
           <DeleteConvoButton convoId={convoId} title='Confirm' />
-          <button
-            className='button button-rounded mx-2 my-2 border-2 border-black'
-            onClick={toggleModal}
-          >
+          <button className='button button-rounded m-2' onClick={toggleModal}>
             Cancel
           </button>
         </div>
       )}
-    </>
+    </div>
   );
 };
 

--- a/components/DeleteConvoModal.tsx
+++ b/components/DeleteConvoModal.tsx
@@ -31,7 +31,7 @@ const DeleteConvoModal = ({ name, convoId, message }: ModalProps) => {
           </div>
           <DeleteConvoButton convoId={convoId} title='Confirm' />
           <button
-            className='button button-rounded mx-2 my-2'
+            className='button button-rounded mx-2 my-2 border-2 border-black'
             onClick={toggleModal}
           >
             Cancel

--- a/components/messaging/ConversationCard.tsx
+++ b/components/messaging/ConversationCard.tsx
@@ -1,9 +1,10 @@
 import { ConversationCardType } from '@/utils/messaging/messagingTypes';
 import TickIcon from '../icons/tickIcon';
+import DeleteConvoModal from '../DeleteConvoModal';
 
-// const cutAfterNCharacters = (text: string, n: number): string => {
-//   return text.length > n ? text.substring(0, n) : text;
-// };
+const cutAfterNCharacters = (text: string, n: number): string => {
+  return text.length > n ? text.substring(0, n) : text;
+};
 
 type ConversationCardProps = ConversationCardType & {
   clickHandler: () => void;
@@ -12,25 +13,31 @@ type ConversationCardProps = ConversationCardType & {
 const ConversationCard: React.FC<ConversationCardProps> = ({
   joined_at,
   user_id,
+  conversation_id,
   item_id,
-  // conversations,
+  conversations,
   clickHandler,
 }) => {
-  // const lastMessage =
-  //   conversations.messages[conversations.messages.length - 1]?.message_text ||
-  //   'No messages yet';
+  const lastMessage =
+    conversations.messages[conversations.messages.length - 1]?.message_text ||
+    'No messages yet';
 
-  // const shortenedText = cutAfterNCharacters(lastMessage, 50);
+  const shortenedText = cutAfterNCharacters(lastMessage, 50);
 
   return (
-    <button type='button' onClick={clickHandler}>
+    <button type='button' onClick={clickHandler} className="border-blue-500 border-2">
+                  <DeleteConvoModal
+              name='X'
+              convoId={conversation_id}
+              message='By pressing "confirm" you will delete this conversation'
+            />
       <div className='m-2 flex max-h-28 flex-col justify-between rounded-lg bg-gray-300 p-4'>
         <div className='flex flex-row items-end justify-between gap-1'>
           <h2 className='font-bold'>{item_id}</h2>
           <span>{user_id}</span>
         </div>
         <p className='mt-1 overflow-hidden text-ellipsis font-light italic'>
-          {/* {shortenedText} ... */}
+          {shortenedText} ...
         </p>
         <div className='flex flex-row items-end justify-between gap-1'>
           <p>{joined_at?.slice(0, 10)}</p>

--- a/components/messaging/ConversationCard.tsx
+++ b/components/messaging/ConversationCard.tsx
@@ -23,7 +23,7 @@ const ConversationCard: React.FC<ConversationCardProps> = ({
   const shortenedText = cutAfterNCharacters(lastMessage, 50);
 
   return (
-    <button type='button' onClick={clickHandler} className="border-blue-500 border-2">
+    <button type='button' onClick={clickHandler}>
       <div className='m-2 flex max-h-28 flex-col justify-between rounded-lg bg-gray-300 p-4'>
         <div className='flex flex-row items-end justify-between gap-1'>
           <h2 className='font-bold'>{item_id}</h2>

--- a/components/messaging/ConversationCard.tsx
+++ b/components/messaging/ConversationCard.tsx
@@ -1,6 +1,5 @@
 import { ConversationCardType } from '@/utils/messaging/messagingTypes';
 import TickIcon from '../icons/tickIcon';
-import DeleteConvoModal from '../DeleteConvoModal';
 
 const cutAfterNCharacters = (text: string, n: number): string => {
   return text.length > n ? text.substring(0, n) : text;
@@ -13,7 +12,6 @@ type ConversationCardProps = ConversationCardType & {
 const ConversationCard: React.FC<ConversationCardProps> = ({
   joined_at,
   user_id,
-  conversation_id,
   item_id,
   conversations,
   clickHandler,
@@ -26,11 +24,6 @@ const ConversationCard: React.FC<ConversationCardProps> = ({
 
   return (
     <button type='button' onClick={clickHandler} className="border-blue-500 border-2">
-                  <DeleteConvoModal
-              name='X'
-              convoId={conversation_id}
-              message='By pressing "confirm" you will delete this conversation'
-            />
       <div className='m-2 flex max-h-28 flex-col justify-between rounded-lg bg-gray-300 p-4'>
         <div className='flex flex-row items-end justify-between gap-1'>
           <h2 className='font-bold'>{item_id}</h2>

--- a/components/messaging/ConversationWrapper.tsx
+++ b/components/messaging/ConversationWrapper.tsx
@@ -23,7 +23,7 @@ const ConversationWrapper: React.FC = () => {
         </button>
       </div>
       {isBreakpoint ? (
-        <div className='mt-4'>
+        <div className='mt-4 p-2'>
           {showConversationsList ? (
             <ConversationsList />
           ) : (
@@ -36,12 +36,13 @@ const ConversationWrapper: React.FC = () => {
           )}
         </div>
       ) : (
-        <div className='mt-4'>
+        <div className='p2 mt-4 border-2 border-black flex flex-row justify-between'>
           <ConversationsList />
           <CurrentConversation />
         </div>
       )}
-    </>
+      </>
+  
   );
 };
 

--- a/components/messaging/ConversationWrapper.tsx
+++ b/components/messaging/ConversationWrapper.tsx
@@ -36,13 +36,12 @@ const ConversationWrapper: React.FC = () => {
           )}
         </div>
       ) : (
-        <div className='p2 mt-4 border-2 border-black flex flex-row justify-between'>
+        <div className='p2 mt-4 flex flex-row justify-between'>
           <ConversationsList />
           <CurrentConversation />
         </div>
       )}
-      </>
-  
+    </>
   );
 };
 

--- a/components/messaging/ConversationsList.tsx
+++ b/components/messaging/ConversationsList.tsx
@@ -65,11 +65,11 @@ const ConversationsList: React.FC = () => {
   }, [supabase, allConversations, setAllConversations]);
 
   return (
-<div className="border-2 border-red-500 m-4">
+    <div className='m-4'>
       {allConversations.length > 0 ? (
         allConversations.map((conversation, index) => (
           <div key={`${conversation.id}-${index}`}>
-                        <DeleteConvoModal
+            <DeleteConvoModal
               name='X'
               convoId={conversation.conversation_id}
               message='By pressing "confirm" you will delete this conversation'
@@ -88,7 +88,7 @@ const ConversationsList: React.FC = () => {
       ) : (
         <p>There are no active conversations</p>
       )}
- </div>
+    </div>
   );
 };
 

--- a/components/messaging/ConversationsList.tsx
+++ b/components/messaging/ConversationsList.tsx
@@ -65,7 +65,7 @@ const ConversationsList: React.FC = () => {
   }, [supabase, allConversations, setAllConversations]);
 
   return (
-    <>
+<div className="border-2 border-red-500 m-4">
       {allConversations.length > 0 ? (
         allConversations.map((conversation, index) => (
           <div key={`${conversation.id}-${index}`}>
@@ -78,17 +78,17 @@ const ConversationsList: React.FC = () => {
               conversations={conversation.conversations}
               clickHandler={() => updateOpenConvo(conversation.conversation_id)}
             />
-            <DeleteConvoModal
+            {/* <DeleteConvoModal
               name='X'
               convoId={conversation.conversation_id}
               message='By pressing "confirm" you will delete this conversation'
-            />
+            /> */}
           </div>
         ))
       ) : (
         <p>There are no active conversations</p>
       )}
-    </>
+ </div>
   );
 };
 

--- a/components/messaging/ConversationsList.tsx
+++ b/components/messaging/ConversationsList.tsx
@@ -69,6 +69,11 @@ const ConversationsList: React.FC = () => {
       {allConversations.length > 0 ? (
         allConversations.map((conversation, index) => (
           <div key={`${conversation.id}-${index}`}>
+                        <DeleteConvoModal
+              name='X'
+              convoId={conversation.conversation_id}
+              message='By pressing "confirm" you will delete this conversation'
+            />
             <ConversationCard
               id={conversation.conversation_id}
               joined_at={conversation.joined_at}
@@ -78,11 +83,6 @@ const ConversationsList: React.FC = () => {
               conversations={conversation.conversations}
               clickHandler={() => updateOpenConvo(conversation.conversation_id)}
             />
-            {/* <DeleteConvoModal
-              name='X'
-              convoId={conversation.conversation_id}
-              message='By pressing "confirm" you will delete this conversation'
-            /> */}
           </div>
         ))
       ) : (

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -59,7 +59,7 @@ const CurrentConversation: React.FC = () => {
   }, [supabase, currentMessages, setCurrentMessages]);
 
   return (
-    <div className='flex w-2/4 flex-col'>
+    <div className='flex w-2/4 flex-col border-2 border-red-500 m-4'>
       {currentMessages.map((message: MessageType) => (
         <div key={`${message.id}-${message.created_at}`}>
           <MessageCard

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -61,7 +61,7 @@ const CurrentConversation: React.FC = () => {
   return (
     <div className='mb-10 flex h-screen flex-1 flex-col justify-end'>
       <div className='flex flex-col-reverse overflow-y-auto bg-stone-50'>
-        {[...currentMessages].reverse().map((message: MessageType) => (
+        {currentMessages.map((message: MessageType) => (
           <div key={`${message.id}-${message.created_at}`}>
             <MessageCard
               sender_id={message.sender_id}

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -59,7 +59,7 @@ const CurrentConversation: React.FC = () => {
   }, [supabase, currentMessages, setCurrentMessages]);
 
   return (
-    <div className='flex w-2/4 flex-col border-2 border-red-500 m-4'>
+    <div className='flex flex-col'>
       {currentMessages.map((message: MessageType) => (
         <div key={`${message.id}-${message.created_at}`}>
           <MessageCard

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -59,18 +59,20 @@ const CurrentConversation: React.FC = () => {
   }, [supabase, currentMessages, setCurrentMessages]);
 
   return (
-    <div className='flex flex-col'>
-      {currentMessages.map((message: MessageType) => (
-        <div key={`${message.id}-${message.created_at}`}>
-          <MessageCard
-            sender_id={message.sender_id}
-            created_at={message.created_at}
-            message_text={message.message_text}
-            is_read={message.is_read}
-            currentUser={currentConversation?.user_id}
-          />
-        </div>
-      ))}
+    <div className='mb-10 flex h-screen flex-1 flex-col justify-end'>
+      <div className='flex flex-col-reverse overflow-y-auto bg-stone-50'>
+        {[...currentMessages].reverse().map((message: MessageType) => (
+          <div key={`${message.id}-${message.created_at}`}>
+            <MessageCard
+              sender_id={message.sender_id}
+              created_at={message.created_at}
+              message_text={message.message_text}
+              is_read={message.is_read}
+              currentUser={currentConversation?.user_id}
+            />
+          </div>
+        ))}
+      </div>
       <MessageForm
         user_id={currentConversation?.user_id}
         conversation_id={currentConversation?.conversation_id}

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -61,7 +61,7 @@ const CurrentConversation: React.FC = () => {
   return (
     <div className='mb-10 flex h-screen flex-1 flex-col justify-end'>
       <div className='flex flex-col-reverse overflow-y-auto bg-stone-50'>
-        {currentMessages.map((message: MessageType) => (
+        {[...currentMessages].reverse().map((message: MessageType) => (
           <div key={`${message.id}-${message.created_at}`}>
             <MessageCard
               sender_id={message.sender_id}

--- a/components/messaging/MessageCard.tsx
+++ b/components/messaging/MessageCard.tsx
@@ -23,7 +23,7 @@ const MessageCard: React.FC<MessageCardProps> = ({
 
   return (
     <div
-      className={`message-card ${isCurrentUser ? 'float-right' : 'float-left'}`}
+      className={`message-card ${isCurrentUser ? 'float-right' : 'float-left'} my-2`}
     >
       <p
         className={`text-lg text-slate-500 ${isCurrentUser ? 'mr-2 text-right' : 'ml-2 text-left'}`}

--- a/components/messaging/MessageForm.tsx
+++ b/components/messaging/MessageForm.tsx
@@ -26,7 +26,7 @@ const MessageForm: React.FC<MessageFormProps> = ({
       {/* <div className='fixed inset-x-0 bottom-0'> */}
       <form onSubmit={handleSubmit} className='m-2 flex justify-between'>
         <textarea
-          className='green-border-card min-h-max w-5/6 bg-stone-50 px-4 py-2 text-black'
+          className='green-border-card h-20 min-h-max w-5/6 bg-stone-50 px-4 py-2 text-black'
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           placeholder='Type your message here'

--- a/components/messaging/MessageForm.tsx
+++ b/components/messaging/MessageForm.tsx
@@ -26,11 +26,6 @@ const MessageForm: React.FC<MessageFormProps> = ({
       onSubmit={handleSubmit}
       className='m-2 flex justify-between text-black'
     >
-      <button type='submit'>
-        <div className='m-2 flex h-10 w-10 items-center gap-1 rounded-full border-2 border-solid border-primaryGreen p-2 '>
-          <PaperPlaneIcon></PaperPlaneIcon>
-        </div>
-      </button>
       <textarea
         className='green-border-card input-text min-h-max w-5/6 px-4 py-2 text-black'
         value={message}
@@ -38,6 +33,11 @@ const MessageForm: React.FC<MessageFormProps> = ({
         placeholder='Type your message here'
         rows={10}
       />
+      <button type='submit'>
+        <div className='m-2 flex h-10 w-10 items-center gap-1 rounded-full border-2 border-solid border-primaryGreen p-2 '>
+          <PaperPlaneIcon></PaperPlaneIcon>
+        </div>
+      </button>
     </form>
   );
 };

--- a/components/messaging/MessageForm.tsx
+++ b/components/messaging/MessageForm.tsx
@@ -22,23 +22,23 @@ const MessageForm: React.FC<MessageFormProps> = ({
   const [message, setMessage] = useState<string>('');
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className='m-2 flex justify-between text-black'
-    >
-      <textarea
-        className='green-border-card input-text min-h-max w-5/6 px-4 py-2 text-black'
-        value={message}
-        onChange={(e) => setMessage(e.target.value)}
-        placeholder='Type your message here'
-        rows={10}
-      />
-      <button type='submit'>
-        <div className='m-2 flex h-10 w-10 items-center gap-1 rounded-full border-2 border-solid border-primaryGreen p-2 '>
-          <PaperPlaneIcon></PaperPlaneIcon>
-        </div>
-      </button>
-    </form>
+    <div>
+      {/* <div className='fixed inset-x-0 bottom-0'> */}
+      <form onSubmit={handleSubmit} className='m-2 flex justify-between'>
+        <textarea
+          className='green-border-card min-h-max w-5/6 bg-stone-50 px-4 py-2 text-black'
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder='Type your message here'
+          rows={10}
+        />
+        <button type='submit'>
+          <div className='m-2 flex h-10 w-10 items-center gap-1 rounded-full border-2 border-solid border-primaryGreen p-2 '>
+            <PaperPlaneIcon></PaperPlaneIcon>
+          </div>
+        </button>
+      </form>
+    </div>
   );
 };
 


### PR DESCRIPTION
Following our conversation this morning, I haven't changed the style of the button but I have moved it so that it is inside the conversations card:

<img width="412" alt="Screenshot 2024-02-23 at 11 48 09" src="https://github.com/fac28/kindly/assets/114364165/8dff5bf9-7777-43b7-a75a-ad6aca527e1c">

I have put a scroll in to the current conversation messages as per convention:

<img width="433" alt="Screenshot 2024-02-23 at 11 49 08" src="https://github.com/fac28/kindly/assets/114364165/a4c2a924-7670-49b7-8985-148858ce0584">

This involved reversing the order of the current conversations array that we map through to render the messages in
components/messaging/CurrentConversation.tsx (to ensure that the most recent messages are displayed at the bottom of the div) I created a shallow copy to avoid interfering with the original array. This could potentially become a performance concern if the list of messages is very long. But if we have a reasonable number of messages displayed at once, this should not be an issue, especially if pagination or infinite scrolling is implemented to limit the number of messages in the DOM at any given time.

Desktop view:
<img width="1330" alt="Screenshot 2024-02-23 at 11 54 51" src="https://github.com/enBloc-org/kindly/assets/114364165/662c1efa-8b73-4a2f-a116-a8acc6bff808">
