### PR TITLE
#77/date markers

### DIFF
--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -7,8 +7,8 @@ import { useContext, useEffect, useState, useRef } from 'react';
 import useConversation from '../../app/(dashboard)/conversations/useConversation';
 import { createSupabaseClient as supabase } from '@/utils/supabase/createSupabaseClient';
 import {
-  createTimeMarker,
-  createDateMarker,
+  formatTimeMarker,
+  formatDateMarker,
 } from '@/utils/messaging/formatTimeStamp';
 
 const CurrentConversation: React.FC = () => {
@@ -92,17 +92,17 @@ const CurrentConversation: React.FC = () => {
       >
         {currentMessages.map((message: MessageType, index: number) => (
           <div key={`${message.id}-${message.created_at}`}>
-            {createDateMarker(message.created_at) !==
-              createDateMarker(currentMessages[index - 1]?.created_at) && (
+            {formatDateMarker(message.created_at) !==
+              formatDateMarker(currentMessages[index - 1]?.created_at) && (
               <div
                 className={`${isScrolling ? 'opacity-100' : 'opacity-100'} sticky top-4 z-10 my-[-15px] ml-[calc((100%_-_120px)/2)] h-[30px] w-[120px] rounded-xl bg-stone-50 object-center p-1 text-center text-lg font-semibold text-slate-400 transition transition-opacity ease-in-out`}
               >
-                {createDateMarker(message.created_at)}
+                {formatDateMarker(message.created_at)}
               </div>
             )}
             <MessageCard
               sender_id={message.sender_id}
-              created_at={createTimeMarker(message.created_at)}
+              created_at={formatTimeMarker(message.created_at)}
               message_text={message.message_text}
               is_read={message.is_read}
               currentUser={currentConversation?.user_id}

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -60,9 +60,15 @@ const CurrentConversation: React.FC = () => {
 
   return (
     <div className='mb-10 flex h-screen flex-1 flex-col justify-end'>
-      <div className='flex flex-col-reverse overflow-y-auto bg-stone-50'>
-        {currentMessages.map((message: MessageType) => (
+      <div className='relative flex flex-col overflow-y-auto bg-stone-50'>
+        {currentMessages.map((message: MessageType, index: number) => (
           <div key={`${message.id}-${message.created_at}`}>
+            {message.created_at.slice(0, 10) !==
+              currentMessages[index - 1]?.created_at.slice(0, 10) && (
+              <span className='absolute right-2/4 rounded-xl bg-primaryGreen p-1 text-center text-white'>
+                {message.created_at.slice(0, 10)}
+              </span>
+            )}
             <MessageCard
               sender_id={message.sender_id}
               created_at={message.created_at}

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -66,7 +66,7 @@ const CurrentConversation: React.FC = () => {
 
       const debounce = setTimeout(() => {
         setIsScrolling(false);
-      }, 2000);
+      }, 3000);
 
       return () => clearTimeout(debounce);
     };

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -6,49 +6,10 @@ import MessageForm from './MessageForm';
 import { useContext, useEffect, useState, useRef } from 'react';
 import useConversation from '../../app/(dashboard)/conversations/useConversation';
 import { createSupabaseClient as supabase } from '@/utils/supabase/createSupabaseClient';
-
-/**
- *
- * @param givenString expects a date format string or timestamptz type from supabase
- * @param length will be considered 'long' by default or can be set to 'short' when calling the function
- * @returns a formatted date stamp in long form by default (i.e.: 01 Januaray 2000) or short form if the second parameter is fed (i.e.: 01 01 2000)
- */
-const formatDate = (givenString: string, length: string = 'long'): string => {
-  try {
-    const givenDate: Date = new Date(givenString);
-    const monthsArray = [
-      'January',
-      'February',
-      'March',
-      'April',
-      'May',
-      'June',
-      'July',
-      'August',
-      'September',
-      'October',
-      'November',
-      'December',
-    ];
-
-    const currentDate = new Date();
-    if (length === 'short') {
-      return givenDate.getDate() === currentDate.getDate() &&
-        givenDate.getUTCMonth() === currentDate.getUTCMonth() &&
-        givenDate.getFullYear() === currentDate.getFullYear()
-        ? 'today'
-        : `${givenDate.getUTCDate()} ${monthsArray[givenDate.getMonth()]}`;
-    } else if (length !== 'long') {
-      throw new Error(
-        'The length parameter can only be set to "short" or the default value "long"'
-      );
-    }
-
-    return `${givenDate.getUTCDate()} ${monthsArray[givenDate.getMonth()]} ${givenDate.getFullYear()}`;
-  } catch (error) {
-    throw error;
-  }
-};
+import {
+  createTimeMarker,
+  createDateMarker,
+} from '@/utils/messaging/formatTimeStamp';
 
 const CurrentConversation: React.FC = () => {
   const { allConversations, currentConversation, setCurrentConversation } =
@@ -131,17 +92,17 @@ const CurrentConversation: React.FC = () => {
       >
         {currentMessages.map((message: MessageType, index: number) => (
           <div key={`${message.id}-${message.created_at}`}>
-            {formatDate(message.created_at) !==
-              formatDate(currentMessages[index - 1]?.created_at) && (
+            {createDateMarker(message.created_at) !==
+              createDateMarker(currentMessages[index - 1]?.created_at) && (
               <div
                 className={`${isScrolling ? 'opacity-100' : 'opacity-100'} sticky top-4 z-10 my-[-15px] ml-[calc((100%_-_120px)/2)] h-[30px] w-[120px] rounded-xl bg-stone-50 object-center p-1 text-center text-lg font-semibold text-slate-400 transition transition-opacity ease-in-out`}
               >
-                {formatDate(message.created_at, 'short')}
+                {createDateMarker(message.created_at)}
               </div>
             )}
             <MessageCard
               sender_id={message.sender_id}
-              created_at={formatDate(message.created_at)}
+              created_at={createTimeMarker(message.created_at)}
               message_text={message.message_text}
               is_read={message.is_read}
               currentUser={currentConversation?.user_id}

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -37,7 +37,7 @@ const formatDate = (givenString: string, length: string = 'long'): string => {
         givenDate.getUTCMonth() === currentDate.getUTCMonth() &&
         givenDate.getFullYear() === currentDate.getFullYear()
         ? 'today'
-        : `${givenDate.getUTCDate()} ${givenDate.getUTCMonth() + 1} ${givenDate.getFullYear()}`;
+        : `${givenDate.getUTCDate()} ${monthsArray[givenDate.getMonth()]}`;
     } else if (length !== 'long') {
       throw new Error(
         'The length parameter can only be set to "short" or the default value "long"'
@@ -126,7 +126,7 @@ const CurrentConversation: React.FC = () => {
   return (
     <div className='mb-10 flex h-screen flex-1 flex-col justify-end'>
       <div
-        className='relative flex flex-col overflow-y-auto bg-stone-50'
+        className='relative flex flex-col-reverse overflow-y-auto bg-stone-50'
         ref={chatWindowRef}
       >
         {currentMessages.map((message: MessageType, index: number) => (
@@ -134,7 +134,7 @@ const CurrentConversation: React.FC = () => {
             {formatDate(message.created_at) !==
               formatDate(currentMessages[index - 1]?.created_at) && (
               <div
-                className={`${isScrolling ? 'opacity-100' : 'opacity-100'} sticky top-4 z-10 my-[-15px] ml-[calc((100%_-_92px)/2)] h-[30px] w-[92px] rounded-xl bg-stone-50 object-center p-1 text-center text-lg font-semibold text-slate-400 transition transition-opacity ease-in-out`}
+                className={`${isScrolling ? 'opacity-100' : 'opacity-100'} sticky top-4 z-10 my-[-15px] ml-[calc((100%_-_120px)/2)] h-[30px] w-[120px] rounded-xl bg-stone-50 object-center p-1 text-center text-lg font-semibold text-slate-400 transition transition-opacity ease-in-out`}
               >
                 {formatDate(message.created_at, 'short')}
               </div>

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -31,10 +31,11 @@ const formatDate = (givenString: string, length: string = 'long'): string => {
       'December',
     ];
 
+    const currentDate = new Date();
     if (length === 'short') {
-      return givenDate.getDate() === new Date().getDate() &&
-        givenDate.getUTCMonth() === new Date().getUTCMonth() &&
-        givenDate.getFullYear() === new Date().getFullYear()
+      return givenDate.getDate() === currentDate.getDate() &&
+        givenDate.getUTCMonth() === currentDate.getUTCMonth() &&
+        givenDate.getFullYear() === currentDate.getFullYear()
         ? 'today'
         : `${givenDate.getUTCDate()} ${givenDate.getUTCMonth() + 1} ${givenDate.getFullYear()}`;
     } else if (length !== 'long') {

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -65,9 +65,9 @@ const CurrentConversation: React.FC = () => {
           <div key={`${message.id}-${message.created_at}`}>
             {message.created_at.slice(0, 10) !==
               currentMessages[index - 1]?.created_at.slice(0, 10) && (
-              <span className='absolute right-2/4 rounded-xl bg-primaryGreen p-1 text-center text-white'>
+              <div className='sticky top-4 z-10 ml-[calc((100%_-_92px)/2)] w-[92px] rounded-xl bg-primaryGreen object-center p-1 text-center text-white'>
                 {message.created_at.slice(0, 10)}
-              </span>
+              </div>
             )}
             <MessageCard
               sender_id={message.sender_id}

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -134,7 +134,7 @@ const CurrentConversation: React.FC = () => {
             {formatDate(message.created_at) !==
               formatDate(currentMessages[index - 1]?.created_at) && (
               <div
-                className={`${isScrolling ? 'opacity-100' : 'opacity-0'} sticky top-4 z-10 my-[-15px] ml-[calc((100%_-_92px)/2)] h-[30px] w-[92px] rounded-xl bg-primaryGreen object-center p-1 text-center text-white transition transition-opacity ease-in-out`}
+                className={`${isScrolling ? 'opacity-100' : 'opacity-100'} sticky top-4 z-10 my-[-15px] ml-[calc((100%_-_92px)/2)] h-[30px] w-[92px] rounded-xl bg-stone-50 object-center p-1 text-center text-lg font-semibold text-slate-400 transition transition-opacity ease-in-out`}
               >
                 {formatDate(message.created_at, 'short')}
               </div>

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -7,6 +7,48 @@ import { useContext, useEffect, useState, useRef } from 'react';
 import useConversation from '../../app/(dashboard)/conversations/useConversation';
 import { createSupabaseClient as supabase } from '@/utils/supabase/createSupabaseClient';
 
+/**
+ *
+ * @param givenString expects a date format string or timestamptz type from supabase
+ * @param length will be considered 'long' by default or can be set to 'short' when calling the function
+ * @returns a formatted date stamp in long form by default (i.e.: 01 Januaray 2000) or short form if the second parameter is fed (i.e.: 01 01 2000)
+ */
+const formatDate = (givenString: string, length: string = 'long'): string => {
+  try {
+    const givenDate: Date = new Date(givenString);
+    const monthsArray = [
+      'January',
+      'February',
+      'March',
+      'April',
+      'May',
+      'June',
+      'July',
+      'August',
+      'September',
+      'October',
+      'November',
+      'December',
+    ];
+
+    if (length === 'short') {
+      return givenDate.getDate() === new Date().getDate() &&
+        givenDate.getUTCMonth() === new Date().getUTCMonth() &&
+        givenDate.getFullYear() === new Date().getFullYear()
+        ? 'today'
+        : `${givenDate.getUTCDate()} ${givenDate.getUTCMonth() + 1} ${givenDate.getFullYear()}`;
+    } else if (length !== 'long') {
+      throw new Error(
+        'The length parameter can only be set to "short" or the default value "long"'
+      );
+    }
+
+    return `${givenDate.getUTCDate()} ${monthsArray[givenDate.getMonth()]} ${givenDate.getFullYear()}`;
+  } catch (error) {
+    throw error;
+  }
+};
+
 const CurrentConversation: React.FC = () => {
   const { allConversations, currentConversation, setCurrentConversation } =
     useContext(useConversation);
@@ -88,17 +130,17 @@ const CurrentConversation: React.FC = () => {
       >
         {currentMessages.map((message: MessageType, index: number) => (
           <div key={`${message.id}-${message.created_at}`}>
-            {message.created_at.slice(0, 10) !==
-              currentMessages[index - 1]?.created_at.slice(0, 10) && (
+            {formatDate(message.created_at) !==
+              formatDate(currentMessages[index - 1]?.created_at) && (
               <div
                 className={`${isScrolling ? 'opacity-100' : 'opacity-0'} sticky top-4 z-10 my-[-15px] ml-[calc((100%_-_92px)/2)] h-[30px] w-[92px] rounded-xl bg-primaryGreen object-center p-1 text-center text-white transition transition-opacity ease-in-out`}
               >
-                {message.created_at.slice(0, 10)}
+                {formatDate(message.created_at, 'short')}
               </div>
             )}
             <MessageCard
               sender_id={message.sender_id}
-              created_at={message.created_at}
+              created_at={formatDate(message.created_at)}
               message_text={message.message_text}
               is_read={message.is_read}
               currentUser={currentConversation?.user_id}

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -66,7 +66,7 @@ const CurrentConversation: React.FC = () => {
 
       const debounce = setTimeout(() => {
         setIsScrolling(false);
-      }, 3000);
+      }, 2000);
 
       return () => clearTimeout(debounce);
     };
@@ -91,7 +91,7 @@ const CurrentConversation: React.FC = () => {
             {message.created_at.slice(0, 10) !==
               currentMessages[index - 1]?.created_at.slice(0, 10) && (
               <div
-                className={`${!isScrolling && 'hidden'} sticky top-4 z-10 ml-[calc((100%_-_92px)/2)] w-[92px] rounded-xl bg-primaryGreen object-center p-1 text-center text-white`}
+                className={`${isScrolling ? 'opacity-100' : 'opacity-0'} sticky top-4 z-10 my-[-15px] ml-[calc((100%_-_92px)/2)] h-[30px] w-[92px] rounded-xl bg-primaryGreen object-center p-1 text-center text-white transition transition-opacity ease-in-out`}
               >
                 {message.created_at.slice(0, 10)}
               </div>

--- a/components/messaging/MessageCard.tsx
+++ b/components/messaging/MessageCard.tsx
@@ -19,8 +19,7 @@ const MessageCard: React.FC<MessageCardProps> = ({
   currentUser,
 }) => {
   const isCurrentUser = sender_id === currentUser;
-  const dateStamp = created_at.slice(0, 10).replaceAll('-', ' ');
-
+  const dateStamp = created_at;
   return (
     <div
       className={`message-card ${isCurrentUser ? 'float-right' : 'float-left'} my-2`}

--- a/components/messaging/MessageCard.tsx
+++ b/components/messaging/MessageCard.tsx
@@ -19,7 +19,7 @@ const MessageCard: React.FC<MessageCardProps> = ({
   currentUser,
 }) => {
   const isCurrentUser = sender_id === currentUser;
-  const dateStamp = created_at;
+
   return (
     <div
       className={`message-card ${isCurrentUser ? 'float-right' : 'float-left'} my-2`}
@@ -27,7 +27,7 @@ const MessageCard: React.FC<MessageCardProps> = ({
       <p
         className={`text-lg text-slate-500 ${isCurrentUser ? 'mr-2 text-right' : 'ml-2 text-left'}`}
       >
-        {dateStamp}
+        {created_at}
       </p>
       <div>
         <p className='green-border-card'>{message_text}</p>

--- a/utils/messaging/formatTimeStamp.ts
+++ b/utils/messaging/formatTimeStamp.ts
@@ -1,0 +1,44 @@
+/**
+ *
+ * @param givenString expects a date format string or timestamptz value from supabase
+ * @returns a formatted string displaying the hour and minute stamp passed i.e.: 13:32
+ */
+export const createTimeMarker = (givenString: string): string => {
+  const givenDate: Date = new Date(givenString);
+
+  return `${givenDate.getHours().toString()}:${givenDate.getMinutes().toString()}`;
+};
+
+/**
+ *
+ * @param givenString expects a date format string or timestamptz type from supabase
+ * @returns a string formatted to match our date stamps (i.e.: 01 Januaray) or the string 'today' if the given date matches the current date
+ */
+export const createDateMarker = (givenString: string): string => {
+  try {
+    const givenDate: Date = new Date(givenString);
+    const monthsArray = [
+      'January',
+      'February',
+      'March',
+      'April',
+      'May',
+      'June',
+      'July',
+      'August',
+      'September',
+      'October',
+      'November',
+      'December',
+    ];
+
+    const currentDate = new Date();
+    return givenDate.getDate() === currentDate.getDate() &&
+      givenDate.getUTCMonth() === currentDate.getUTCMonth() &&
+      givenDate.getFullYear() === currentDate.getFullYear()
+      ? 'today'
+      : `${givenDate.getUTCDate()} ${monthsArray[givenDate.getMonth()]}`;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/utils/messaging/formatTimeStamp.ts
+++ b/utils/messaging/formatTimeStamp.ts
@@ -3,7 +3,7 @@
  * @param givenString expects a date format string or timestamptz value from supabase
  * @returns a formatted string displaying the hour and minute stamp passed i.e.: 13:32
  */
-export const createTimeMarker = (givenString: string): string => {
+export const formatTimeMarker = (givenString: string): string => {
   const givenDate: Date = new Date(givenString);
 
   const hoursValue =
@@ -24,7 +24,7 @@ export const createTimeMarker = (givenString: string): string => {
  * @param givenString expects a date format string or timestamptz type from supabase
  * @returns a string formatted to match our date stamps (i.e.: 01 Januaray) or the string 'today' if the given date matches the current date
  */
-export const createDateMarker = (givenString: string): string => {
+export const formatDateMarker = (givenString: string): string => {
   try {
     const givenDate: Date = new Date(givenString);
     const monthsArray = [

--- a/utils/messaging/formatTimeStamp.ts
+++ b/utils/messaging/formatTimeStamp.ts
@@ -6,7 +6,17 @@
 export const createTimeMarker = (givenString: string): string => {
   const givenDate: Date = new Date(givenString);
 
-  return `${givenDate.getHours().toString()}:${givenDate.getMinutes().toString()}`;
+  const hoursValue =
+    givenDate.getHours().toString().split('').length < 2
+      ? '0' + givenDate.getHours().toString()
+      : givenDate.getHours().toString();
+
+  const minutesValue =
+    givenDate.getMinutes().toString().split('').length < 2
+      ? '0' + givenDate.getMinutes().toString()
+      : givenDate.getMinutes().toString();
+
+  return `${hoursValue}:${minutesValue}`;
 };
 
 /**


### PR DESCRIPTION
Added markers for each new day that are only visible if the user is scrolling through messages - pretty much emulated the behaviour of any major messaging app out there.

This div is only rendered whenever the date of the message is a different day from the previous message - this is done with an evaluation in the .map method using the index value which we are now calling there.

![Screenshot 2024-02-26 at 18 11 48](https://github.com/enBloc-org/kindly/assets/114600712/fa40b586-6b13-4866-a87d-72e0791c4430)

![Screenshot 2024-02-26 at 18 19 30](https://github.com/enBloc-org/kindly/assets/114600712/f3aa7b6f-819b-4b27-beaa-121be230270f)

Date Markers have the following behaviour:
- Will stay at the top when scrolling and replace one-another in sequence
- Will fade out after 3 seconds of the user no longer scrolling
- Will stay centred in any screen size
- Will always be juxtaposed over MessageCards

The following lines will have to be reviewed if we are changing the return value of the date on our database query, which I am happy to take on in a separate PR if no one is working on it right now, but I thought it best to keep it out of this request:

```js
 {message.created_at.slice(0, 10) !==  // we'll need to adjust this evaluation depending on what we are actually returning
              currentMessages[index - 1]?.created_at.slice(0, 10) && ( // for now I am doing the manipulation in-line
              <div
                className={`${isScrolling ? 'opacity-100' : 'opacity-0'} sticky top-4`}
              >
                {message.created_at.slice(0, 10)}
              </div>
            )}
```

@eliazzo - I have removed the `flex-col-reverse` while working on this to see the final result, but my understanding is that it was intended to help with keeping the messages scrolled to the bottom, which we are now tackling differently. So do we need the messages in reverse order for any other reason?

P.S.: Got to play around with debouncing which was really fun 🎪 