### PR TITLE
#76/message card styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -55,23 +55,3 @@ body {
 .card {
   @apply overflow-hidden rounded-lg bg-white px-8  pb-5 shadow-sm transition-all hover:scale-95 hover:shadow-lg lg:text-lg;
 }
-
-.message-card {
-  @apply relative min-h-max w-5/6 overflow-hidden rounded-lg px-4 py-2 sm:w-96 lg:text-lg;
-}
-
-.green-border-card {
-  @apply rounded-xl border-2 border-solid border-primaryGreen p-4;
-}
-
-.conversation-height {
-  height: calc(100vh - 225px);
-  border: solid 2px red;
-}
-
-@media screen and (min-width: 1000px) {
-  .conversation-height {
-    height: calc(100vh - 155px);
-    border: solid 2px red;
-  }
-}

--- a/app/globals.css
+++ b/app/globals.css
@@ -50,16 +50,28 @@ body {
   @apply rounded-3xl border border-primaryGreen bg-background px-5 py-3 text-sm md:w-80;
 }
 
-/*  Card hover animation */
+/*  Cards */
 
 .card {
   @apply overflow-hidden rounded-lg bg-white px-8  pb-5 shadow-sm transition-all hover:scale-95 hover:shadow-lg lg:text-lg;
 }
 
 .message-card {
-  @apply relative min-h-max w-5/6 overflow-hidden rounded-lg bg-background px-4 py-2 text-black transition-all sm:w-96 lg:text-lg;
+  @apply relative min-h-max w-5/6 overflow-hidden rounded-lg px-4 py-2 sm:w-96 lg:text-lg;
 }
 
 .green-border-card {
   @apply rounded-xl border-2 border-solid border-primaryGreen p-4;
+}
+
+.conversation-height {
+  height: calc(100vh - 225px);
+  border: solid 2px red;
+}
+
+@media screen and (min-width: 1000px) {
+  .conversation-height {
+    height: calc(100vh - 155px);
+    border: solid 2px red;
+  }
 }

--- a/app/styles/messaging-styles.css
+++ b/app/styles/messaging-styles.css
@@ -1,5 +1,6 @@
 .message-card {
-  @apply relative min-h-max w-5/6 overflow-hidden rounded-lg px-4 py-2 sm:w-96 lg:text-lg;
+  @apply mx-4 my-6 flex w-5/6 items-stretch justify-between 
+  rounded-2xl px-6 py-4 shadow-md;
 }
 
 .conversation-height {

--- a/app/styles/messaging-styles.css
+++ b/app/styles/messaging-styles.css
@@ -1,5 +1,5 @@
 .message-card {
-  @apply mx-4 my-6 flex w-5/6 items-stretch justify-between 
+  @apply relative mx-4 my-6 flex w-5/6 items-stretch justify-between 
   rounded-2xl px-6 py-4 shadow-md;
 }
 
@@ -10,5 +10,15 @@
 @media screen and (min-width: 1000px) {
   .conversation-height {
     height: calc(100vh - 155px);
+  }
+
+  /* .message-card{ 
+    @apply w-4/6
+  } */
+}
+
+@media screen and (min-width: 1400px) {
+  .message-card {
+    @apply w-4/6;
   }
 }

--- a/app/styles/messaging-styles.css
+++ b/app/styles/messaging-styles.css
@@ -1,0 +1,7 @@
+.message-card {
+  @apply relative min-h-max w-5/6 overflow-hidden rounded-lg px-4 py-2 sm:w-96 lg:text-lg;
+}
+
+.green-border-card {
+  @apply rounded-xl border-2 border-solid border-primaryGreen p-4;
+}

--- a/app/styles/messaging-styles.css
+++ b/app/styles/messaging-styles.css
@@ -2,6 +2,12 @@
   @apply relative min-h-max w-5/6 overflow-hidden rounded-lg px-4 py-2 sm:w-96 lg:text-lg;
 }
 
-.green-border-card {
-  @apply rounded-xl border-2 border-solid border-primaryGreen p-4;
+.conversation-height {
+  height: calc(100vh - 225px);
+}
+
+@media screen and (min-width: 1000px) {
+  .conversation-height {
+    height: calc(100vh - 155px);
+  }
 }

--- a/components/messaging/ConversationWrapper.tsx
+++ b/components/messaging/ConversationWrapper.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { useContext } from 'react';
-import MeatballIcon from '../icons/MeatballIcon';
-import PlusIcon from '../icons/PlusIcon';
 import ConversationsList from './ConversationsList';
 import CurrentConversation from './CurrentConversation';
 import useConversation from '@/app/(dashboard)/conversations/useConversation';
@@ -15,12 +13,6 @@ const ConversationWrapper: React.FC = () => {
   return (
     <>
       <div className='mt-4 flex justify-between px-3 '>
-        <button>
-          <PlusIcon width={45} height={45} />
-        </button>
-        <button>
-          <MeatballIcon width={35} height={35} />
-        </button>
       </div>
       {isBreakpoint ? (
         <div className='mt-4 p-2'>

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -59,8 +59,8 @@ const CurrentConversation: React.FC = () => {
   }, [supabase, currentMessages, setCurrentMessages]);
 
   return (
-    <div className='mb-10 flex h-screen flex-1 flex-col justify-end'>
-      <div className='flex flex-col-reverse overflow-y-auto bg-stone-50'>
+    <div className='conversation-height mb-10 flex flex-1 flex-col justify-between'>
+      <div className='flex flex-col overflow-y-auto'>
         {currentMessages.map((message: MessageType) => (
           <div key={`${message.id}-${message.created_at}`}>
             <MessageCard

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -87,28 +87,30 @@ const CurrentConversation: React.FC = () => {
   return (
     <div className='conversation-height mb-10 flex flex-1 flex-col justify-between bg-[#fafaf9] shadow-inner'>
       <div
-        className='relative flex flex-col overflow-y-auto overflow-x-hidden'
+        className='relative flex h-full flex-col-reverse overflow-y-auto overflow-x-hidden'
         ref={chatWindowRef}
       >
-        {currentMessages.map((message: MessageType, index: number) => (
-          <div key={`${message.id}-${message.created_at}`}>
-            {formatDateMarker(message.created_at) !==
-              formatDateMarker(currentMessages[index - 1]?.created_at) && (
-              <div
-                className={`${isScrolling ? 'opacity-100' : 'opacity-0'} sticky top-4 z-10 my-[-15px] ml-[calc((100%_-_120px)/2)] h-[30px] w-[120px] rounded-xl bg-stone-50 object-center p-1 text-center text-lg font-semibold text-slate-400 transition transition-opacity ease-in-out`}
-              >
-                {formatDateMarker(message.created_at)}
-              </div>
-            )}
-            <MessageCard
-              sender_id={message.sender_id}
-              created_at={formatTimeMarker(message.created_at)}
-              message_text={message.message_text}
-              is_read={message.is_read}
-              currentUser={currentConversation?.user_id}
-            />
-          </div>
-        ))}
+        {currentMessages
+          .map((message: MessageType, index: number) => (
+            <div key={`${message.id}-${message.created_at}`}>
+              {formatDateMarker(message.created_at) !==
+                formatDateMarker(currentMessages[index - 1]?.created_at) && (
+                <div
+                  className={`${isScrolling ? 'opacity-100' : 'opacity-0'} sticky top-4 z-10 my-[-15px] ml-[calc((100%_-_120px)/2)] h-[30px] w-[120px] rounded-xl bg-stone-50 object-center p-1 text-center text-lg font-semibold text-slate-400 transition transition-opacity ease-in-out`}
+                >
+                  {formatDateMarker(message.created_at)}
+                </div>
+              )}
+              <MessageCard
+                sender_id={message.sender_id}
+                created_at={formatTimeMarker(message.created_at)}
+                message_text={message.message_text}
+                is_read={message.is_read}
+                currentUser={currentConversation?.user_id}
+              />
+            </div>
+          ))
+          .reverse()}
       </div>
       <MessageForm
         user_id={currentConversation?.user_id}

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -86,13 +86,16 @@ const CurrentConversation: React.FC = () => {
 
   return (
     <div className='conversation-height mb-10 flex flex-1 flex-col justify-between bg-[#fafaf9] shadow-inner'>
-      <div className='flex flex-col overflow-y-auto overflow-x-hidden'>
+      <div
+        className='relative flex flex-col overflow-y-auto overflow-x-hidden'
+        ref={chatWindowRef}
+      >
         {currentMessages.map((message: MessageType, index: number) => (
           <div key={`${message.id}-${message.created_at}`}>
             {formatDateMarker(message.created_at) !==
               formatDateMarker(currentMessages[index - 1]?.created_at) && (
               <div
-                className={`${isScrolling ? 'opacity-100' : 'opacity-100'} sticky top-4 z-10 my-[-15px] ml-[calc((100%_-_120px)/2)] h-[30px] w-[120px] rounded-xl bg-stone-50 object-center p-1 text-center text-lg font-semibold text-slate-400 transition transition-opacity ease-in-out`}
+                className={`${isScrolling ? 'opacity-100' : 'opacity-0'} sticky top-4 z-10 my-[-15px] ml-[calc((100%_-_120px)/2)] h-[30px] w-[120px] rounded-xl bg-stone-50 object-center p-1 text-center text-lg font-semibold text-slate-400 transition transition-opacity ease-in-out`}
               >
                 {formatDateMarker(message.created_at)}
               </div>

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -59,8 +59,8 @@ const CurrentConversation: React.FC = () => {
   }, [supabase, currentMessages, setCurrentMessages]);
 
   return (
-    <div className='conversation-height mb-10 flex flex-1 flex-col justify-between'>
-      <div className='flex flex-col overflow-y-auto'>
+    <div className='conversation-height mb-10 flex flex-1 flex-col justify-between shadow-inner'>
+      <div className='flex flex-col overflow-y-auto overflow-x-hidden'>
         {currentMessages.map((message: MessageType) => (
           <div key={`${message.id}-${message.created_at}`}>
             <MessageCard

--- a/components/messaging/MessageCard.tsx
+++ b/components/messaging/MessageCard.tsx
@@ -19,25 +19,19 @@ const MessageCard: React.FC<MessageCardProps> = ({
   currentUser,
 }) => {
   const isCurrentUser = sender_id === currentUser;
-  const dateStamp = created_at.slice(0, 10).replaceAll('-', ' ');
+  console.log(created_at);
 
   return (
     <div
-      className={`message-card ${isCurrentUser ? 'float-right' : 'float-left'} my-2`}
+      className={`message-card ${isCurrentUser ? 'float-right bg-secondaryGray' : 'float-left bg-secondaryGreen'} my-2`}
     >
-      <p
-        className={`text-lg text-slate-500 ${isCurrentUser ? 'mr-2 text-right' : 'ml-2 text-left'}`}
-      >
-        {dateStamp}
-      </p>
-      <div>
-        <p>{message_text}</p>
+      <div className='mx-2 flex items-center justify-center'>
+        <p className='text-lg'>{message_text}</p>
       </div>
-      {isCurrentUser && (
-        <div className='relative float-right mr-4'>
-          <TickIcon read={is_read} />
-        </div>
-      )}
+      <div className='flex flex-1 flex-col items-end justify-between gap-2'>
+        <p className='text-sm font-light'>13:40</p>
+        <TickIcon read={is_read} />
+      </div>
     </div>
   );
 };

--- a/components/messaging/MessageCard.tsx
+++ b/components/messaging/MessageCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React from 'react';
 import TickIcon from '../icons/tickIcon';
-import '../../app/styles/messaging-styles.css'
+import '../../app/styles/messaging-styles.css';
 
 type MessageCardProps = {
   sender_id: string;
@@ -31,7 +31,7 @@ const MessageCard: React.FC<MessageCardProps> = ({
         {dateStamp}
       </p>
       <div>
-        <p className='green-border-card'>{message_text}</p>
+        <p>{message_text}</p>
       </div>
       {isCurrentUser && (
         <div className='relative float-right mr-4'>

--- a/components/messaging/MessageCard.tsx
+++ b/components/messaging/MessageCard.tsx
@@ -23,13 +23,19 @@ const MessageCard: React.FC<MessageCardProps> = ({
 
   return (
     <div
-      className={`message-card ${isCurrentUser ? 'float-right bg-secondaryGray' : 'float-left bg-secondaryGreen'} my-2`}
+      className={`message-card ${isCurrentUser ? 'float-right bg-secondaryGray lg:left-24' : 'float-left bg-secondaryGreen lg:right-10'} my-2`}
     >
       <div className='mx-2 flex items-center justify-center'>
-        <p className='text-lg'>{message_text}</p>
+        <p
+          className={`px-2 py-2 text-lg ${message_text.length > 50 ? 'md:px-4' : ''} ${isCurrentUser ? '' : 'lg:ml-10'}`}
+        >
+          {message_text}
+        </p>
       </div>
-      <div className='flex flex-1 flex-col items-end justify-between gap-2'>
-        <p className='text-sm font-light'>13:40</p>
+      <div
+        className={`flex flex-1 flex-col items-end justify-between gap-2 ${isCurrentUser ? 'lg:mr-24' : ''}`}
+      >
+        <p className='text-sm font-light lg:text-base'>13:40</p>
         <TickIcon read={is_read} />
       </div>
     </div>

--- a/components/messaging/MessageCard.tsx
+++ b/components/messaging/MessageCard.tsx
@@ -29,16 +29,16 @@ const MessageCard: React.FC<MessageCardProps> = ({
     >
       <div className='mx-2 flex items-center justify-center'>
         <p
-          className={`px-2 py-2 text-lg ${message_text.length > 50 ? 'md:px-4' : ''} ${isCurrentUser ? '' : 'lg:ml-10'}`}
+          className={`px-2 py-2 text-lg ${message_text.length > 50 && 'md:px-4'} lg:ml-10`}
         >
           {message_text}
         </p>
       </div>
       <div
-        className={`flex flex-1 flex-col items-end justify-between gap-2 ${isCurrentUser ? 'lg:mr-24' : ''}`}
+        className={`flex flex-1 flex-col items-end justify-between gap-2 ${isCurrentUser && 'lg:mr-24'}`}
       >
         <p className='text-sm font-light lg:text-base'>13:40</p>
-        <TickIcon read={is_read} />
+        {isCurrentUser && <TickIcon read={is_read} />}
       </div>
     </div>
   );

--- a/components/messaging/MessageCard.tsx
+++ b/components/messaging/MessageCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React from 'react';
-
 import TickIcon from '../icons/tickIcon';
+import '../../app/styles/messaging-styles.css'
 
 type MessageCardProps = {
   sender_id: string;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,9 +11,9 @@ module.exports = {
         backgroundHighlight: '#E0DFDE',
         primaryGreen: '#54BB89',
         hoverGreen: '#4EA37A',
-        secondaryGreen: '#008000',
+        secondaryGreen: '#B6DFB6',
         primaryGray: '#57666D',
-        secondaryGray: '#D9D9D9',
+        secondaryGray: '#DCDCDC',
         primaryOrange: '#FF9E5E',
       },
       fontFamily: {


### PR DESCRIPTION
-Styled message components to look like figma mockup
-Updated the tailwind config  to contain the colours for messaging (bg-secondary-(gray and green)).
-Styled the CurrentConversation component so it has correct height and takes into account the header and mobile nav bar.
-merge this branch with dev.

Mobile view:

<img width="469" alt="Screenshot 2024-03-01 at 12 22 47" src="https://github.com/fac28/kindly/assets/74174344/1c33ec6e-9129-4516-88c9-1d78ef5e8ee1">

Desktop:

<img width="1261" alt="Screenshot 2024-03-01 at 12 27 30" src="https://github.com/fac28/kindly/assets/74174344/7245e15b-2952-446b-8687-b706fc595571">
