### PR TITLE
#90/bugfix-supabase-channel

### DIFF
--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -51,10 +51,14 @@ const CurrentConversation: React.FC = () => {
           table: 'messages',
         },
         (payload) => {
-          setCurrentMessages((prevMessages) => [
-            ...prevMessages,
-            payload.new as MessageType,
-          ]);
+          if (
+            payload.new.conversation_id === currentConversation?.conversation_id
+          ) {
+            setCurrentMessages((prevMessages) => [
+              ...prevMessages,
+              payload.new as MessageType,
+            ]);
+          }
         }
       )
       .subscribe();


### PR DESCRIPTION
Supabase channel is now only actively listening to changes on the currentConversation

Closes #90

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review on my code
- [x] I have made corresponding changes to the documentation (if any were needed)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and previously existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description

Before enacting any changes to the UI our supabase websocket is now checking whether the currentConversation ID matches the ID of the conversation that sent a payload with the `INSERT` action on the `realtime messages` channel.

This removed the bug reported in this issue.

### Files changed

`CurrentConversation.tsx` has had an evaluation added to the `useEffect()` handling re-render for new messages.

### UI changes

No changes to UI 🙅 

### Changes to Documentation

No documentation needed as this was just a bug fix - the app behaves the same way we intended before.

# Tests

No new tests as there was no feature added.

The bug reported was noticed when two developers were working on the `/conversations` route in the same server so I don't really see a test that I could add to account for this fringe case. 

**However**I verified the fix by running two separate windows on the same server an logging a message to the one that should not see the new messages appear. The behaviour was as expected.

All prior tests are passing