### PR TITLE
bug: deleteConversation function and modal now user userId and delete…

### DIFF
--- a/components/messaging/ConversationCardModal.tsx
+++ b/components/messaging/ConversationCardModal.tsx
@@ -7,6 +7,7 @@ import deleteConversation from '../../utils/messaging/deleteConversation';
 //Components
 import ElipsisMenu from '../menus/EllipsisMenu';
 import ButtonRounded from '../buttons/ButtonRounded';
+import { useConversationContext } from '@/context/conversationContext';
 
 type ModalProps = {
   conversationId?: number;
@@ -17,6 +18,8 @@ const ConversationCardModal = ({ conversationId, message }: ModalProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [error, setError] = useState('');
   const [isDisabled, setIsDisabled] = useState(false);
+
+  const { currentConversation } = useConversationContext();
 
   const toggleModalClickHandler = (
     event: React.MouseEvent<HTMLButtonElement>
@@ -29,14 +32,15 @@ const ConversationCardModal = ({ conversationId, message }: ModalProps) => {
     event: React.MouseEvent<HTMLButtonElement>
   ) => {
     event.stopPropagation();
-    if (typeof conversationId === 'undefined') {
-      throw new Error('item is undefined');
+    if (
+      typeof conversationId === 'undefined' ||
+      typeof currentConversation?.user_id === 'undefined'
+    ) {
+      throw new Error('Conversation is undefined');
     }
     try {
       setIsDisabled(true);
-      console.log({ conversationId });
-
-      deleteConversation(conversationId);
+      deleteConversation(conversationId, currentConversation.user_id);
       setIsModalOpen(false);
       setError('');
       setIsDisabled(false);

--- a/utils/messaging/deleteConversation.ts
+++ b/utils/messaging/deleteConversation.ts
@@ -1,15 +1,17 @@
 import newClient from '../../config/supabaseclient';
 
-export default async function deleteConversation(convIDtobeDeleted: number) {
+export default async function deleteConversation(
+  conversationId: number,
+  userId: string
+) {
   try {
     const supabase = newClient();
-    const { data, error } = await supabase
+    const { error } = await supabase
       .from('user_conversations')
       .delete()
-      .match({ id: convIDtobeDeleted });
+      .match({ conversation_id: conversationId, user_id: userId });
 
     if (error) throw error;
-    console.log(data);
   } catch (error) {
     console.error('Error deleting conversation:', error);
   }


### PR DESCRIPTION
… by column conversation_id

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review on my code
- [x] I have made corresponding changes to the documentation (if any were needed)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and previously existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description

**Relates #139 / Closes #139**

Fixed bug where conversation where not being deleted properly. This was redoing previous work that possibly got undone in a merge. 
Conversations now delete by conversation_id and also by user_id. 

### Files changed

components/messaging/ConversationCardModal.tsx - use conversation context to get userId and pass it to the deleteConversation function.

utils/messaging/deleteConversation.ts - update modal to correct match parameters.

# Tests

Include a description of any tests added - if none have been added explain why.
