### PR TITLE
#159/incorrect use of label for

### DIFF
--- a/components/AuthForm.tsx
+++ b/components/AuthForm.tsx
@@ -76,6 +76,8 @@ const AuthForm: React.FC<AuthFormProps> = ({
       </label>
       <input
         className='mb-2 rounded border border-primaryGreen bg-white p-2 shadow'
+        type='email'
+        autoComplete='email'
         id='email'
         name='email'
         placeholder='you@example.com'

--- a/components/AuthForm.tsx
+++ b/components/AuthForm.tsx
@@ -110,7 +110,7 @@ const AuthForm: React.FC<AuthFormProps> = ({
           <input
             className='mb-2 rounded border border-primaryGreen bg-white p-2 shadow'
             type='password'
-            id='confitmPassword'
+            id='confirmPassword'
             name='password'
             placeholder='••••••••'
             onChange={(e) => setConfirmPassword(e.target.value)}

--- a/components/AuthForm.tsx
+++ b/components/AuthForm.tsx
@@ -64,6 +64,7 @@ const AuthForm: React.FC<AuthFormProps> = ({
           </label>
           <input
             className='mb-2 rounded border border-primaryGreen bg-white p-2 shadow'
+            id='user_name'
             name='user_name'
             placeholder='Your Username'
             required
@@ -75,6 +76,7 @@ const AuthForm: React.FC<AuthFormProps> = ({
       </label>
       <input
         className='mb-2 rounded border border-primaryGreen bg-white p-2 shadow'
+        id='email'
         name='email'
         placeholder='you@example.com'
         required
@@ -86,6 +88,7 @@ const AuthForm: React.FC<AuthFormProps> = ({
         <input
           className='mb-2 rounded border border-primaryGreen bg-white p-2 shadow'
           type={showPassword ? 'text' : 'password'}
+          id='password'
           name='password'
           placeholder='••••••••'
           onChange={(e) => setPassword(e.target.value)}
@@ -107,6 +110,7 @@ const AuthForm: React.FC<AuthFormProps> = ({
           <input
             className='mb-2 rounded border border-primaryGreen bg-white p-2 shadow'
             type='password'
+            id='confitmPassword'
             name='password'
             placeholder='••••••••'
             onChange={(e) => setConfirmPassword(e.target.value)}


### PR DESCRIPTION
# Description

Relates #159 

On the Auth page there were not ID for email and name. It was working as expected but this may induce errors on the browser's autocomplete. 

### Files changed

/components/Auth.Form.tsx