### PR TITLE
#209/Link 🔗 to PRIVACY.md from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You can also connect with the developing community on our [discord server](https
 - [Contributing](https://github.com/enBloc-org/kindly/blob/dev/.github/CONTRIBUTING.md) <sup>1</sup>
 - [Best practice](https://github.com/enBloc-org/kindly/blob/dev/.github/BEST_PRACTICE.md)
 - [Testing](https://github.com/enBloc-org/kindly/blob/dev/.github/TESTING.md)
-- [Privacy](https://github.com/enBloc-org/kindly/blob/dev/.github/PRIVACY.md)
+- [Privacy](https://github.com/enBloc-org/kindly/blob/dev/PRIVACY.md)
 
 <sup>1</sup> All PR's must request a merge to the base repository: ```enBloc-org/kindly``` base: ```dev```
 


### PR DESCRIPTION
docs: updated README.md with the relevant link to PRIVACY.md

relates #209

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review on my code
- [ ] I have made corresponding changes to the documentation (if any were needed)
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and previously existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description

**Relates #[209] <u>OR</u> Closes #[issue number]**  
There's a link in the README.md file that is intended to give visitors to the repo a quick view of the privacy statement.
This should navigate directly to the already created PRIVACY.md document in our repo.

### Files changed

updated README.md with the relevant link to PRIVACY.md

### UI changes

no changes

### Changes to Documentation

The PRIVACY.md file should be displayed along with the readme, license and code of conduct in the repo

# Tests

I tested the link and it redirects to PRIVACY.md
