### PR TITLE
#232/stale workflow input

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,8 +10,6 @@ permissions:
 
 jobs:
   stale:
-    env:
-      repo-token: ${{secrets.GITHUB_TOKEN}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
           # stale and delete issues
           stale-issue-message: '🤖 meep morp! This Issue is now marked as stale because there has been no activity for a while.  The Issue may be unassigned and moved to the Backlog or it will get deleted if there is no activity in the next 7 days.'
           close-issue-message: '🤖 meep morp :( This Issue has been closed because it was stale for 7 days.'


### PR DESCRIPTION
# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review on my code
- [ ] I have made corresponding changes to the documentation (if any were needed)
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and previously existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description

**Closes #232**  
Trivial cleanups on the stale issue/PR workflow.

### Files changed

`.github/workflows/stale.yml`:
- 325a157 Removed an invalid action input.
  - Is causing the `Unexpected input(s) 'GITHUB_TOKEN'` warning in the workflow runs ([example](https://github.com/enBloc-org/kindly/actions/runs/9295893813)).
- 7378aa2 Removed an unnecessary environment variable.
  - `actions/stale` already sets `repo-token` with the token by default ([doc](https://github.com/actions/stale?tab=readme-ov-file#repo-token)).

# Tests

Here's [an example of a workflow run](https://github.com/mnixo/kindly/actions/runs/9302334127) with the proposed changes.