### PR TITLE
#243/add Node.js version

### DIFF
--- a/.github/BEFORE_YOUR_FIRST_ISSUE.md
+++ b/.github/BEFORE_YOUR_FIRST_ISSUE.md
@@ -34,7 +34,7 @@ Go to the project directory:
   cd kindly
 ```
 
-Install dependencies:
+With Node.js 20, install the project dependencies:
 
 ```bash
   npm install


### PR DESCRIPTION
# Description

**Closes #243**  

Adds a reference to the Node.js version that should be used.
If there is no set Node.js version as of yet, my suggestion is to use [Node.js 20](https://nodejs.org/en/about/previous-releases):
- Is the Active LTS until ~October 2024.
- Scheduled maintenance window until ~April 2026.

### Files changed

`.github/BEFORE_YOUR_FIRST_ISSUE.md`

### UI changes

N/A.

### Changes to Documentation

This is a documentation PR.

# Tests

Tested locally using `node@v20.14.0` and `npm@10.7.0`.
