### PR TITLE
#269/review workflows

### DIFF
--- a/.github/workflows/auto-assign-issue.yml
+++ b/.github/workflows/auto-assign-issue.yml
@@ -1,0 +1,28 @@
+name: Auto assign Issue
+
+on:
+    issues:
+        types: [opened]
+
+jobs:
+    auto-assign:
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Check if it's been requested
+              id: check-if-requested
+              run: |
+                  ISSUE_BODY=$(jq -r .issue.body "$GITHUB_EVENT_PATH")
+                  echo "Issue Body: $ISSUE_BODY"
+                  if echo "$ISSUE_BODY" | grep -q "I'd like to work on this Issue myself"; then
+                    echo "self-assigned=true" >> $GITHUB_ENV
+                  else
+                    echo "self-assigned=false" >> $GITHUB_ENV
+                  fi
+
+            - name: Assign to issuer
+              if: env.self-assigned == 'true'
+              uses: actions-ecosystem/action-add-assignees@v1
+              with:
+                  github_token: ${{secrets.GITHUB_TOKEN}}
+                  assignees: ${{github.event.issue.user.login}}

--- a/.github/workflows/auto-unassign-issue.yml
+++ b/.github/workflows/auto-unassign-issue.yml
@@ -1,0 +1,27 @@
+name: Auto Unassign Inactive Issues
+
+on:
+  schedule:
+    - cron: '00 17 * * *'
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  unassign-inactive-issues:
+    name: Unnassign inactive issues
+    runs-on: ubuntu@latest
+    steps:
+      - uses: boundfoxstudios/action-unassign-contributor-after-days-of-inactivity@main
+        with:
+          last-activity: 7
+          labels: 'Stale'
+          labels-to-remove: 'Stale'
+          message: |
+            🤖 meep morp!
+
+            This issue has been stale for 7 days so it's being automaticaly unassigned and will return to the backlog.
+
+            💡 Once in the Backlog this issue will be available for anyone to take up - you can request it again if you have contributions ready to submit.

--- a/.github/workflows/request-assigning-issue.yml
+++ b/.github/workflows/request-assigning-issue.yml
@@ -1,0 +1,42 @@
+name: Assign Issue
+
+on:
+  schedule:
+    - cron: 0 9 * * *
+  issue_comment:
+    types: [created]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign the user or unassign stale assignments
+        uses: takanome-dev/assign-issue-action@v2.1.1
+        with:
+          trigger: '!request'
+          assigned_label: 🧑‍💻 assigned
+          pin_label: 🧑‍💻 assigned
+          assigned_comment: |
+            🤖 meep morp!
+
+            Thank you for your contribution @{{comment.user.login}} - this Issue is assigned to you as requested ✨
+
+            🔎 Please keep in mind that in order to give everyone a chance to contribute Issues may be unassigned if they go stale.
+            You will be warned if the Issue is marked as stale at any point.
+
+            🔎 Please review our documentation for guidance on:
+            - common Patterns we follow in the code base
+            - conventions set for commit messages and naming of functions, classes or files
+
+            💡 The core team is available for any help and will try to respond to any comments in this Issue or questions on discord as quickly as possible.
+
+            Happy coding ! 🦆
+          already_assigned_comment: |
+            🤖 meep morp!
+
+            Thank you for your interest @{{comment.user.login}}, but it looks like this issue is already assigned to someone.
+
+            🔎 We try to keep issues assigned only to one developer unless they have planned to collaborate directly.
+            If you have discussed this issue with the developer currently assigned and would like to help please let us know in a comment and someone from the core team will manually add you to the Issue.
+
+            🔎 If this Issue returns to the backlog for any reason please feel free to request it then.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: 'Close stale Issues and PRs'
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: '00 9 * * *'
 
 permissions:
   contents: write
@@ -9,18 +9,30 @@ permissions:
   pull-requests: write
 
 jobs:
-  stale:
+  stale-inactive-issues:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9
         with:
+          days-before-close: -1 # this value will keep issues and prs from being closed
+          include-only-assigned: true # issues in the backlog will not become stale
+
           # stale and delete issues
-          stale-issue-message: '🤖 meep morp! This Issue is now marked as stale because there has been no activity for a while.  The Issue may be unassigned and moved to the Backlog or it will get deleted if there is no activity in the next 7 days.'
-          close-issue-message: '🤖 meep morp :( This Issue has been closed because it was stale for 7 days.'
-          days-before-issue-stale: 21
-          days-before-issue-close: 7
+          stale-issue-message: |
+            🤖 meep morp! 
+            
+            This Issue is now marked as stale because there has been no activity for a while.
+            
+            🔎 The Issue will be automaticaly unassigned and moved to the Backlog if it doesn't receive new activity in the next 7 days.
+
+            💡 To unstale this Issue please push any commits that are ready or provide an update in the comments.
+          days-before-issue-stale: 7
 
           # stale pull requests
-          stale-pr-message: '🤖 meep morp! This PR is now marked as stale because there has been no activity for a while.  Please guarantee this is still a relevant PR.'
-          days-before-pr-stale: 14
-          days-before-pr-close: -1 # Applying a negative value means the pr will not be closed and is simply being marked as stale
+          stale-pr-message: |
+            🤖 meep morp! 
+            
+            This PR is now marked as stale because there has been no activity for a while.
+            
+            💡 Please guarantee this is still a relevant PR.
+          days-before-pr-stale: 7


### PR DESCRIPTION
# Description

**Closes #269 ** & **Closes #240 **  

This PR replaces deprecated workflows and sets new automations that make better use of the setup made at the organisation level.

### Files changed

- `auto-assign-issue.yml` - makes use of the dropdown menu in our github forms to auto assign an issue if it was requested by the creator
- `auto-unassign-issue.yml` - will auto unassign an issue if it has been stale for 7 days, making it available to other collaborators
- `stale.yml` - no longer deletes issues, allowing the unassign workflow to take place instead and no longer affects unassigned issues
- `request-assigning-issue.yml` - allows collaborators to request an issue with a set keyword in comments to make getting start on your issues faster by removing the need for a member of the core team to manually assign them to you

### UI changes

No UI changes 

### Changes to Documentation

- `CONTRIBUTING.md` - updated to inform collaborators of the keyword to use in comments to request an issue and with guidance on how stale issues are managed.

# Tests

The workflows were manually tested by running in a separate repo
