### PR TITLE
fix: stopped items from being reserved on start new conversation

### DIFF
--- a/components/buttons/NewConversationButton.tsx
+++ b/components/buttons/NewConversationButton.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import startNewConversation from '@/supabase/models/messaging/startNewConversation';
 import { useEffect } from 'react';
-import editRow from '@/supabase/models/editRow';
 import { useConversationContext } from '../../context/conversationContext';
 
 export default function NewConversationButton({
@@ -48,12 +47,6 @@ export default function NewConversationButton({
             throw new Error(`HTTP error! Status: ${response.status}`);
           }
           setError(false);
-          await editRow(
-            'items',
-            { reserved: true, reserved_by: userId ?? '' },
-            'id',
-            item_id
-          );
         } catch (error) {
           console.error(error);
         }


### PR DESCRIPTION
# Description

HOT FIX

resolves issue with items being reserved automatically when a new conversation is started

### Files changed

`NewConversationButton.tsx`

### UI changes

none

### Changes to Documentation

none

# Tests

none - tests are all passing
