### PR TITLE
Add Cypress tests to CI

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,38 @@
+name: Cypress
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+      - main
+jobs:
+  tests-e2e:
+    name: E2E tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install npm dependencies
+        run: npm i
+      - name: Start Supabase
+        run: npx supabase start
+      - name: Set env vars
+        run: |
+          output=$(npx supabase status -o env)
+          eval $output
+          echo "NEXT_PUBLIC_SUPABASE_URL=$API_URL" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY" >> $GITHUB_ENV
+          echo "SUPABASE_SERVICE_ROLE_KEY=$SERVICE_ROLE_KEY" >> $GITHUB_ENV
+      - name: Run E2E tests
+        uses: cypress-io/github-action@v6
+        with:
+          start: npm run dev
+          wait-on: 'http://localhost:3000'
+          install: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - dev
+      - main
 jobs:
   tests-interaction:
     name: Interaction tests

--- a/cypress/e2e/anonymous.cy.js
+++ b/cypress/e2e/anonymous.cy.js
@@ -9,6 +9,9 @@ Cypress.on(
   (err) => !err.message.includes('NEXT_REDIRECT')
 );
 
+// timeout to wait for redirects (in ms)
+const redirectTimeout = 10000;
+
 describe('Anonymous Navigation', () => {
   it('Can browse items', () => {
     // go to home page
@@ -40,7 +43,7 @@ describe('Anonymous Navigation', () => {
     cy.visit(page.home, { failOnStatusCode: false });
     // click add item, validate navigation
     HomePage.addItemIcon().click();
-    cy.location('pathname')
+    cy.location('pathname', { timeout: redirectTimeout })
       .should('not.eq', page.addItem)
       .should('eq', page.login);
   });
@@ -50,7 +53,7 @@ describe('Anonymous Navigation', () => {
     cy.visit(page.home, { failOnStatusCode: false });
     // click message, validate navigation
     HomePage.messageIcon().click();
-    cy.location('pathname')
+    cy.location('pathname', { timeout: redirectTimeout })
       .should('not.eq', page.message)
       .should('eq', page.login);
   });
@@ -60,7 +63,7 @@ describe('Anonymous Navigation', () => {
     cy.visit(page.home, { failOnStatusCode: false });
     // click profile, validate navigation
     HomePage.profileIcon().click();
-    cy.location('pathname')
+    cy.location('pathname', { timeout: redirectTimeout })
       .should('not.eq', page.profile)
       .should('eq', page.login);
   });

--- a/cypress/e2e/item.cy.js
+++ b/cypress/e2e/item.cy.js
@@ -1,4 +1,4 @@
-import AddItemPage from '../support/page_objects/AddItemPage';
+import AddItemPage from '../support/page_objects/addItemPage';
 import ProfilePage from '../support/page_objects/profilePage';
 import * as page from '../fixtures/URLs.json';
 import * as data from '../fixtures/inputData.json';


### PR DESCRIPTION
# Description

**Closes #286**  
Introduces a new GitHub Actions workflow to run the Cypress E2E tests.

### Files changed

* `.github/workflows/cypress.yml`: The new workflow file.
  * Runs on `dev` and `main`.
  * Times out after 10 minutes, preventing hanging workflow runs.
  * Installs the project dependencies.
  * Starts Supabase.
  * Sets the environment variables.
  * Simultaneously starts the app and runs the E2E tests using the Cypress action.
* `.github/workflows/storybook.yml`: Runs the storybook tests also on `main`.
* `cypress/e2e/anonymous.cy.js`: Adds redirect timeouts to make tests more resilient (in CI, tests run slower). The timeout represents the maximum time the test is allowed to wait before it fails.
* `cypress/e2e/item.cy.js`: Fixes an import.

# Tests

Have a look at the checks on this PR 😉
