### PR TITLE
fix: now selecting all columns by default but not explicitly to fix r…

### DIFF
--- a/app/(dashboard)/search/[results]/page.tsx
+++ b/app/(dashboard)/search/[results]/page.tsx
@@ -23,7 +23,7 @@ const SearchResulsPage = async ({
   } else {
     searchResults = await getItems(
       'items',
-      '*',
+      '',
       'item_type',
       searchParams.category
     );

--- a/supabase/models/getRecentItems.ts
+++ b/supabase/models/getRecentItems.ts
@@ -4,7 +4,7 @@ export async function getRecentItems() {
   const supabase = newClient();
   const { data, error } = await supabase
     .from('items')
-    .select('*')
+    .select('')
     .order('created_at', { ascending: false })
     .limit(4);
   if (error) {

--- a/supabase/models/getRecentItems.ts
+++ b/supabase/models/getRecentItems.ts
@@ -4,7 +4,7 @@ export async function getRecentItems() {
   const supabase = newClient();
   const { data, error } = await supabase
     .from('items')
-    .select('')
+    .select()
     .order('created_at', { ascending: false })
     .limit(4);
   if (error) {


### PR DESCRIPTION
# Description

**Closes #303**  

Hot Fix for a tester-raised issue.

Newly uploaded items are now found in the 'Uploaded this week' section and when searching items via selecting a category and subcategory (instead of typing in a name).

### Files changed

- `search/[results]/page.tsx` && `getRecentItems.ts` - in both cases I replaced a `.select('*')` value in the database query with `.select('')` to return all columns _by default but not explicitly_. This stops our query results from ignoring any items that are considered `PartialItemType`, which occur naturally due to categories and subcategories having an optional nature.

### UI changes

No changes

### Changes to Documentation

No changes

# Tests

No changes. All our tests pass because they always add an item with all category and subcategory options filled. In new test tickets I'll be adding the request to include a 'toy' type item specifically to cover this scenario the users highlighted.
