### PR TITLE
refactor: added conditional redirect to login if user already exists …

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -19,14 +19,14 @@ export default function SignUp({
       password: formData.get('password') as string,
     });
 
-    if (data.user?.role === '') {
-      return redirect(
-        '/login?message=User already registered. Please try logging in instead.'
-      );
-    }
-
     if (error) {
-      return redirect('/signup?message=Could not authenticate user.');
+      if (error.code === 'user_already_exists') {
+        return redirect(
+          '/login?message=User already registered. Please try logging in instead.'
+        );
+      }
+
+      return redirect(`/signup?message=${error.code?.replaceAll(/_/g, ' ')}.`);
     }
 
     // Get userId and insert it as ID in Profiles table


### PR DESCRIPTION
# Description

**Relates #301**  

Changed our error handling to do the following:
- redirect the user to login if their credentials are already registered
- return the exact error code onto our message instead of the previous generic "Could not Authenticate User"

### Files changed

`/signup/page.tsx` is the only file touched.

### UI changes

All UI is the same but the message passed to the signup or login page in case of an error is now more detailed and derived directly from the auth error

### Changes to Documentation

No changes

# Tests

No changes
