### PR TITLE
#301/redirect on signup

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -2,6 +2,7 @@ import AuthForm from '@/components/AuthForm';
 import insertRow from '@/supabase/models/insertRow';
 import newServerClient from '@/supabase/utils/newServerClient';
 import { PartialProfile } from '@/types/supabaseTypes';
+import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 
 export default function SignUp({
@@ -17,7 +18,7 @@ export default function SignUp({
     const { data, error } = await supabase.auth.signUp({
       email: formData.get('email') as string,
       password: formData.get('password') as string,
-      options: { emailRedirectTo: '/login' },
+      options: { emailRedirectTo: `${headers().get('origin')}/login` },
     });
 
     if (error) {

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -17,6 +17,7 @@ export default function SignUp({
     const { data, error } = await supabase.auth.signUp({
       email: formData.get('email') as string,
       password: formData.get('password') as string,
+      options: { emailRedirectTo: '/login' },
     });
 
     if (error) {

--- a/cypress/e2e/authorisation.cy.js
+++ b/cypress/e2e/authorisation.cy.js
@@ -1,6 +1,7 @@
 import LoginPage from '../support/page_objects/loginPage';
 import HomePage from '../support/page_objects/homePage';
 import ProfilePage from '../support/page_objects/profilePage';
+import SignupPage from '../support/page_objects/signupPage';
 import * as page from '../fixtures/URLs.json';
 
 describe('Authorisation Spec', () => {
@@ -17,5 +18,19 @@ describe('Authorisation Spec', () => {
     cy.visit(page.profile, { failOnStatusCode: false });
     ProfilePage.logoutButton().click();
     LoginPage.loginButton().should('be.visible');
+  });
+
+  it('Attempting to sign up an existing user will redirect to /login', () => {
+    cy.visit(page.signup, { failOnStatusCode: false });
+    SignupPage.usernameInput().type('existing user');
+    SignupPage.emailInput().type(Cypress.env('loginEmail'));
+    SignupPage.passwordInput().type(Cypress.env('loginPassword'));
+    SignupPage.passwordConfirmationInput().type(Cypress.env('loginPassword'));
+    SignupPage.consentCheckbox().check();
+    SignupPage.registerButton().click();
+    LoginPage.loginButton().should('be.visible');
+    cy.get('p')
+      .contains(/user already registered/gi)
+      .should('be.visible');
   });
 });

--- a/cypress/fixtures/URLs.json
+++ b/cypress/fixtures/URLs.json
@@ -1,6 +1,7 @@
 {
   "home": "/",
   "login": "/login",
+  "signup": "/signup",
   "about": "/about",
   "search": "/search",
   "addItem": "/add-item",

--- a/cypress/support/page_objects/signupPage.js
+++ b/cypress/support/page_objects/signupPage.js
@@ -1,0 +1,29 @@
+import BasePage from './basePage';
+
+export class SignupPage extends BasePage {
+  usernameInput() {
+    return cy.get('input[name="user_name"]').should('be.visible');
+  }
+
+  emailInput() {
+    return cy.get('input[name="email"]').should('be.visible');
+  }
+
+  passwordInput() {
+    return cy.get('input[id="password"]').should('be.visible');
+  }
+
+  passwordConfirmationInput() {
+    return cy.get('input[id="confirmPassword"]').should('be.visible');
+  }
+
+  consentCheckbox() {
+    return cy.get('input[id="agreeCheckbox"]').should('be.visible');
+  }
+
+  registerButton() {
+    return cy.get('button').contains(/register/gi);
+  }
+}
+
+export default new SignupPage();


### PR DESCRIPTION
# Description

**Closes #301**  

Trying to signup an existing user now redirects to /login with an explicit message.

Explicit url is being passed to the `emailRedirectTo` option on .signUp()

### Files changed

`signup/page.tsx` - adding email redirect option
`cypress/**` - extended E2E tests to specifically test attempting to signup an existing user

### UI changes

n/a

### Changes to Documentation

n/a

# Tests

New tests described above.