### PR TITLE
refactor: added weak password scenario to error handling on signup

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -28,7 +28,13 @@ export default function SignUp({
         );
       }
 
-      return redirect(`/signup?message=${error.code?.replaceAll(/_/g, ' ')}.`);
+      if (error.code === 'weak_password') {
+        return redirect(
+          `/signup?message=Your password must include at lease one uppercase character, one number and one special character`
+        );
+      }
+
+      return redirect(`/signup?message=${error.code?.replaceAll(/_/g, ' ')}`);
     }
 
     // Get userId and insert it as ID in Profiles table


### PR DESCRIPTION
Closes #261 

This PR sets up better error handling and user response for our password strength requirements.

Supabase provides our authentication and it's possible to set up the desired password strength (at least 6 characters, 1 lowercase, 1 uppercase, 1 numeral and 1 special character) straight from the console.

Unfortunately I have not found a way to record this in the code via the config.toml file and it cannot be set in the local copy of the console - but we can create a new database dump for the schema of the project that will reflect these requirements. 

However, in order to do that we have to set the desired password strength in the production project so I have set up here the error handling that would communicate to the user the exact expectations for their password, if their signup fails.

### Files changed

-`app/(auth)/signup/page.tsx` - setting up error handling to communicate to the user the expectations for their password strength.

### UI changes

No UI changes

### Changes to Documentation

None needed

# Tests

Testing for this specific error message would fail until we actually trigger the change in password requirements on production. All existing tests are passing.
