### PR TITLE
Update testing scripts and documentation guidance on E2E with Cypress

### DIFF
--- a/.github/TESTING.md
+++ b/.github/TESTING.md
@@ -32,3 +32,31 @@ You can learn more about writing tests within the `play` block of your stories b
 All component stories should include tests for any basic functionality provided by the component. All `interactions` tests should be passing in Storybook after any changes to our components.
 
 ![Storybook interactions test suite](./documentation_images/storybook_interactions_suite.png)
+
+## End-to-end Testing (E2E)
+
+[Cypress](https://www.cypress.io/) is the tool used to test the high-level functionality of the application.
+
+[With the app running](https://github.com/enBloc-org/kindly/blob/dev/.github/BEFORE_YOUR_FIRST_ISSUE.md#running-the-app), you can run the Cypress tests with the following command:
+
+```bash
+npx cypress run
+```
+
+Alternatively, if you have Supabase running (but not the app) you can start the app and run the tests simultaneously with:
+
+```bash
+npm run start-dev
+```
+
+The Cypress E2E test files are located in the `cypress/e2e/` folder.
+
+### Developing and debugging E2E tests
+
+As you work on new features and fixes, you may need to write new E2E tests or update existing ones. With the app running, you can run the E2E tests interactively using Launchpad:
+
+```bash
+npx cypress open
+```
+
+Learn more about the Cypress Launchpad by checking out the [**official documentation 📚**](https://docs.cypress.io/guides/getting-started/opening-the-app)

--- a/package.json
+++ b/package.json
@@ -10,10 +10,7 @@
     "format:fix": "prettier --write \"**/*.{js,jsx,ts,tsx,css,scss}\"",
     "format": "prettier --write .",
     "prepare": "husky install",
-    "test": "playwright test -c playwright-ct.config.ts",
-    "changed": "CHANGED_FILES=$(git diff --name-only HEAD^) && [ -n \"$CHANGED_FILES\" ] && npm run test -- $CHANGED_FILES || (echo '\\033[1;31mThere are no tests associated with your changes\\033[0m' && exit 0)",
-    "test:all": "next build && start-server-and-test http://localhost:3654 test",
-    "test:changed": "next build && start-server-and-test http://localhost:3654 changed",
+    "start-test": "start-server-and-test dev http://localhost:3000 'cypress run'",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },


### PR DESCRIPTION
**Closes #319**

Cleans up the `package.json` scripts and adds documentation on how to run the Cypress E2E tests.

### Files changed

- `package.json`:
  - Removes Playwright `test` and other related scripts.
    - Proposes to remove the `changed` and `test:changed` scripts entirely. Running all the tests is not that expensive and safer.
  - Adds `start-test` command.
    - Starts the app in dev mode and runs the E2E tests.
    - Still requires Supabase to be started first.
    - The mixed logs of the app and the tests is not very easy to follow. It might be more practical to use different terminals for debugging.
- `.github/TESTING.md`: adds documentation on how to run and debug the Cypress E2E tests.