### PR TITLE
#296/fix new messages fail

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -320,7 +320,7 @@ SELECT pg_catalog.setval('"public"."items_id_seq"', 5, true);
 -- Name: messages_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('"public"."messages_id_seq"', 9, true);
+SELECT pg_catalog.setval('"public"."messages_id_seq"', 14, true);
 
 
 --


### PR DESCRIPTION
relates #296

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review on my code
- [x] I have made corresponding changes to the documentation ( not needed)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and previously existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (not needed)

# Description
This Pull Request addresses the issue related to the sequence value for "messages_id_seq" in the dev environment. The sequence was updated to 14 to correct discrepancies in IDs.
**Closes #296**  

### Files changed

It only changes one line in `seed.sql` file: 
`SELECT pg_catalog.setval('"public"."messages_id_seq"', 14, true);`

### UI changes
No UI changes were made in this PR.

### Changes to Documentation
No changes to documentation are needed for this PR.

### Tests
No tests are needed at the moment for this PR.
