### PR TITLE
Fix Auto Unassign Inactive Issues workflow

### DIFF
--- a/.github/workflows/auto-unassign-issue.yml
+++ b/.github/workflows/auto-unassign-issue.yml
@@ -12,9 +12,9 @@ permissions:
 jobs:
   unassign-inactive-issues:
     name: Unnassign inactive issues
-    runs-on: ubuntu@latest
+    runs-on: ubuntu-latest
     steps:
-      - uses: boundfoxstudios/action-unassign-contributor-after-days-of-inactivity@main
+      - uses: boundfoxstudios/action-unassign-contributor-after-days-of-inactivity@v1.0.2
         with:
           last-activity: 7
           labels: 'Stale'


### PR DESCRIPTION
**Closes #324**  

### Files changed

`.github/workflows/auto-unassign-issue.yml`:
* Fixes the runner identifier, which was causing runs to hang indefinitely.
* Fixes the version of action used, preventing uncontrolled version bumps.

# Tests

[Example of a successful run of the workflow in my fork](https://github.com/mnixo/kindly/actions/runs/10288666824).
