### PR TITLE
Skip staging deployment when secrets are not set

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -6,21 +6,21 @@ on:
       - dev
   workflow_dispatch:
 
+env:
+  SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+  SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+  SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
-
-    env:
-      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-      SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_PROJECT_ID }}
-
     steps:
       - uses: actions/checkout@v3
-
       - uses: supabase/setup-cli@v1
         with:
           version: latest
-
-      - run: supabase link --project-ref $SUPABASE_PROJECT_ID
-      - run: supabase db push
+      - name: Link project and push
+        if: ${{ env.SUPABASE_PROJECT_ID != '' }}
+        run: |
+          supabase link --project-ref $SUPABASE_PROJECT_ID
+          supabase db push


### PR DESCRIPTION
**Closes #326**  

### Files changed

* `.github/workflows/staging.yml`: The full "Deploy Migrations to Staging" workflow only runs when the necessary `SUPABASE_PROJECT_ID` secret is configured.

Contributors are no longer met with a unsolvable failed status on the `dev` branch of their fork.

This still leaves the door open for any contributor to set their own secret values on their fork. If they do, the workflow will automatically update their own instance, just like it does in the original repository.

The functionality should remain the same on the `dev` branch of the original repository.

# Tests

[See this example of a run in the context of a fork](https://github.com/mnixo/kindly/actions/runs/10326029338/job/28588774064).