### PR TITLE
#329/fix unread

### DIFF
--- a/app/(dashboard)/edit-item/[id]/page.tsx
+++ b/app/(dashboard)/edit-item/[id]/page.tsx
@@ -250,6 +250,7 @@ const EditItemPage = ({ params }: { params: { id: number } }) => {
         <UploadImageInput
           setImageSrc={setImageSrc}
           setError={setGeneralError}
+          imageType='item'
         />
         {generalError && <p className='error-message'>{generalError}</p>}
         <ButtonRounded type='submit'>EDIT ITEM</ButtonRounded>

--- a/app/styles/messaging-styles.css
+++ b/app/styles/messaging-styles.css
@@ -7,6 +7,14 @@
   height: calc(100vh - 165px);
 }
 
+.conversation-card {
+  @apply relative flex items-center bg-gray-300 p-4 lg:max-w-[500px] lg:rounded-lg lg:shadow-md lg:hover:bg-secondaryGray
+}
+
+.notification-dot {
+  @apply relative left-12 z-50 h-4 w-4 rounded-full border-2 border-green-700 bg-[#54BB89] shadow-lg outline-4 outline-black
+}
+
 .conversation-height {
   height: calc(100vh - 65px);
 }

--- a/components/menus/EllipsisMenu.tsx
+++ b/components/menus/EllipsisMenu.tsx
@@ -24,6 +24,7 @@ const EllipsisMenu: React.FC<EllipsisMenuType> = ({ menuOptions }) => {
       <button
         onClick={toggleMenuClickHandler}
         className='rounded-md p-[.05rem] hover:bg-gray-200 hover:bg-opacity-50'
+        name='ellipsis-button'
       >
         <EllipsisIcon width={25} height={25} />
       </button>

--- a/components/messaging/ConversationCard.tsx
+++ b/components/messaging/ConversationCard.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image';
 import ConversationCardModal from './ConversationCardModal';
 import defaultProfileImage from '../../public/default-profile.png';
 import useMediaQuery from '../hooks/useMediaQuery';
+import '../../app/styles/messaging-styles.css';
 
 export type ConversationCardProps = {
   messageTimestamp: string;
@@ -42,23 +43,16 @@ const ConversationCard: React.FC<ConversationCardProps> = ({
 
   return (
     <div
-      className={`relative flex items-center bg-gray-300 p-4 lg:max-w-[500px] lg:rounded-lg lg:shadow-md lg:hover:bg-secondaryGray
+      className={`conversation-card
           ${currentConversationId === conversationId ? 'lg: border-2 lg:border-primaryGreen' : ''}`}
       tabIndex={0}
       aria-label='button'
       onClick={clickHandler}
-      data-testid='card-wrapper'
     >
       <div className='relative h-[65px] w-[65px]'>
         {notificationList.some(
           (conversation) => conversation === conversationId
-        ) && (
-          <div
-            data-testid='notification-dot'
-            className='relative left-12 z-50 h-4 w-4 rounded-full border-2 
-              border-green-700 bg-[#54BB89] shadow-lg outline-4 outline-black'
-          ></div>
-        )}
+        ) && <div className='notification-dot'></div>}
         {partnerAvatar ? (
           <Image
             src={partnerAvatar}

--- a/components/messaging/ConversationCard.tsx
+++ b/components/messaging/ConversationCard.tsx
@@ -54,6 +54,7 @@ const ConversationCard: React.FC<ConversationCardProps> = ({
           (conversation) => conversation === conversationId
         ) && (
           <div
+            data-testid='notification-dot'
             className='relative left-12 z-50 h-4 w-4 rounded-full border-2 
               border-green-700 bg-[#54BB89] shadow-lg outline-4 outline-black'
           ></div>

--- a/components/messaging/ConversationCard.tsx
+++ b/components/messaging/ConversationCard.tsx
@@ -2,7 +2,6 @@ import Image from 'next/image';
 import ConversationCardModal from './ConversationCardModal';
 import defaultProfileImage from '../../public/default-profile.png';
 import useMediaQuery from '../hooks/useMediaQuery';
-import '../../app/styles/messaging-styles.css';
 
 export type ConversationCardProps = {
   messageTimestamp: string;

--- a/components/messaging/ConversationCard.tsx
+++ b/components/messaging/ConversationCard.tsx
@@ -46,6 +46,7 @@ const ConversationCard: React.FC<ConversationCardProps> = ({
           ${currentConversationId === conversationId ? 'lg: border-2 lg:border-primaryGreen' : ''}`}
       tabIndex={0}
       aria-label='button'
+      data-testid='card-wrapper'
       onClick={clickHandler}
     >
       <div className='relative h-[65px] w-[65px]'>

--- a/components/messaging/ConversationsList.tsx
+++ b/components/messaging/ConversationsList.tsx
@@ -16,11 +16,7 @@ const ConversationsList: React.FC = () => {
     dispatch,
   } = useConversationContext();
 
-  const [notificationList, setNotificationList] = useState<number[]>(
-    allConversations
-      .filter((conversation) => conversation.has_unread_messages)
-      .map((conversation) => conversation.conversation_id)
-  );
+  const [notificationList, setNotificationList] = useState<number[]>([]);
   const supabase = newClient();
 
   const updateOpenConversation = async (givenId: number) => {
@@ -36,6 +32,14 @@ const ConversationsList: React.FC = () => {
     updateConversationReadStatus(givenId, currentUserId, false);
     dispatch({ type: 'SET_SHOW_CONVERSATIONS_LIST', payload: false });
   };
+
+  useEffect(() => {
+    setNotificationList(
+      allConversations
+        .filter((conversation) => conversation.has_unread_messages)
+        .map((conversation) => conversation.conversation_id)
+    );
+  }, [allConversations]);
 
   useEffect(() => {
     const channel = supabase

--- a/components/messaging/ConversationsList.tsx
+++ b/components/messaging/ConversationsList.tsx
@@ -16,7 +16,11 @@ const ConversationsList: React.FC = () => {
     dispatch,
   } = useConversationContext();
 
-  const [notificationList, setNotificationList] = useState<number[]>([]);
+  const [notificationList, setNotificationList] = useState<number[]>(
+    allConversations
+      .filter((conversation) => conversation.has_unread_messages)
+      .map((conversation) => conversation.conversation_id)
+  );
   const supabase = newClient();
 
   const updateOpenConversation = async (givenId: number) => {

--- a/components/messaging/MessageForm.tsx
+++ b/components/messaging/MessageForm.tsx
@@ -69,6 +69,7 @@ const MessageForm: React.FC<MessageFormProps> = ({
         className='h-[65px] w-5/6 resize-none overflow-hidden rounded-lg
           border-2 border-gray-300 bg-white px-4 py-2 pt-5 text-black shadow-inner'
         value={message}
+        name='message-input'
         ref={textareaRef}
         onChange={onChangeHandler}
         onKeyDown={onKeydownHandler}
@@ -76,6 +77,7 @@ const MessageForm: React.FC<MessageFormProps> = ({
       />
       <button
         type='submit'
+        name='message-submit-button'
         disabled={isDisabled}
         className={`flex items-center justify-center rounded-full border-2 
           border-solid border-primaryGreen p-3 ${isDisabled ? 'opacity-40' : 'opacity-100'}`}

--- a/cypress/e2e/messaging.cy.js
+++ b/cypress/e2e/messaging.cy.js
@@ -1,0 +1,23 @@
+import * as page from '../fixtures/URLs.json';
+import ConversationsPage from '../support/page_objects/conversationsPage';
+
+describe('messaging feature', () => {
+  beforeEach(() => {
+    cy.login(Cypress.env('loginEmail'), Cypress.env('loginPassword'));
+  });
+
+  it('alerts users for unread messages in a conversation', () => {
+    cy.visit(page.message);
+    ConversationsPage.notificationDot().should('have.length', 2);
+    ConversationsPage.conversationCard().click();
+    ConversationsPage.notificationDot().should('have.length', 1);
+    ConversationsPage.conversationCard()
+      .parents('[data-testid="card-wrapper"]')
+      .find('[name="ellipsis-button"]')
+      .click();
+    cy.get('button')
+      .contains(/mark unread/i)
+      .click();
+    ConversationsPage.notificationDot().should('have.length', 2);
+  });
+});

--- a/cypress/e2e/messaging.cy.js
+++ b/cypress/e2e/messaging.cy.js
@@ -12,7 +12,7 @@ describe('messaging feature', () => {
     ConversationsPage.conversationCard().click();
     ConversationsPage.notificationDot().should('have.length', 1);
     ConversationsPage.conversationCard()
-      .parents('[data-testid="card-wrapper"]')
+      .parents('.conversation-card')
       .find('[name="ellipsis-button"]')
       .click();
     cy.get('button')

--- a/cypress/e2e/messaging.cy.js
+++ b/cypress/e2e/messaging.cy.js
@@ -7,11 +7,11 @@ describe('messaging feature', () => {
   });
 
   it('alerts users for unread messages in a conversation', () => {
-    cy.visit(page.message);
+    cy.visit(page.conversations);
     ConversationsPage.notificationDot().should('have.length', 2);
-    ConversationsPage.conversationCard().click();
+    ConversationsPage.conversationCard(/unread to refugee/i).click();
     ConversationsPage.notificationDot().should('have.length', 1);
-    ConversationsPage.conversationCard()
+    ConversationsPage.conversationCard(/unread to refugee/i)
       .parents('.conversation-card')
       .find('[name="ellipsis-button"]')
       .click();
@@ -19,5 +19,30 @@ describe('messaging feature', () => {
       .contains(/mark unread/i)
       .click();
     ConversationsPage.notificationDot().should('have.length', 2);
+  });
+
+  it('allows users to send new messages', () => {
+    cy.visit(page.conversations);
+    ConversationsPage.messageInput().type('NEW MESSAGE');
+    ConversationsPage.messageSubmitButton().click();
+    ConversationsPage.messageCard(/new message/i);
+  });
+
+  it.only('allows users to delete a conversation', () => {
+    cy.visit(page.conversations);
+    ConversationsPage.conversationCard(/message 4/i)
+      .parents('.conversation-card')
+      .find('[name="ellipsis-button"]')
+      .click();
+    cy.get('button')
+      .contains(/delete/i)
+      .click();
+    cy.get('.overlay')
+      .find('button')
+      .contains(/delete/i)
+      .click();
+    cy.get('.conversation-card')
+      .contains(/message 4/i)
+      .should('not.exist');
   });
 });

--- a/cypress/fixtures/URLs.json
+++ b/cypress/fixtures/URLs.json
@@ -5,7 +5,7 @@
   "about": "/about",
   "search": "/search",
   "addItem": "/add-item",
-  "message": "/conversations",
+  "conversations": "/conversations",
   "profile": "/profile",
   "item": "/item/"
 }

--- a/cypress/support/page_objects/conversationsPage.js
+++ b/cypress/support/page_objects/conversationsPage.js
@@ -1,0 +1,16 @@
+import BasePage from './basePage';
+
+class ConversationsPage extends BasePage {
+  conversationCard() {
+    return cy
+      .get('[data-testid="card-wrapper"]')
+      .contains(/unread to refugee/i)
+      .should('be.visible');
+  }
+
+  notificationDot() {
+    return cy.get('[data-testid="notification-dot"]').should('be.visible');
+  }
+}
+
+export default new ConversationsPage();

--- a/cypress/support/page_objects/conversationsPage.js
+++ b/cypress/support/page_objects/conversationsPage.js
@@ -1,15 +1,40 @@
 import BasePage from './basePage';
 
 class ConversationsPage extends BasePage {
-  conversationCard() {
+  /**
+   *
+   * @param {RegExp} latestMessagePattern expects a RegExp matching the message content of the target ConversationCard
+   * @returns a single ConversationCard element with a last message content matching the pattern passed in
+   */
+  conversationCard(latestMessagePattern) {
     return cy
       .get('.conversation-card')
-      .contains(/unread to refugee/i)
+      .contains(latestMessagePattern)
       .should('be.visible');
   }
 
   notificationDot() {
     return cy.get('.notification-dot').should('be.visible');
+  }
+
+  messageInput() {
+    return cy.get('[name="message-input"]').should('be.visible');
+  }
+
+  messageSubmitButton() {
+    return cy.get('[name="message-submit-button"]').should('be.visible');
+  }
+
+  /**
+   *
+   * @param {RegExp} messagePattern expects a RegExp matching the text of your target MessageCard component
+   * @returns a single MessageCard component with a message content matching the pattern passed in
+   */
+  messageCard(messagePattern) {
+    return cy
+      .get('.message-card')
+      .contains(messagePattern)
+      .should('be.visible');
   }
 }
 

--- a/cypress/support/page_objects/conversationsPage.js
+++ b/cypress/support/page_objects/conversationsPage.js
@@ -3,13 +3,13 @@ import BasePage from './basePage';
 class ConversationsPage extends BasePage {
   conversationCard() {
     return cy
-      .get('[data-testid="card-wrapper"]')
+      .get('.conversation-card')
       .contains(/unread to refugee/i)
       .should('be.visible');
   }
 
   notificationDot() {
-    return cy.get('[data-testid="notification-dot"]').should('be.visible');
+    return cy.get('.notification-dot').should('be.visible');
   }
 }
 

--- a/supabase/migrations/20240906121523_fix_return_type_for_select_user_conversations.sql
+++ b/supabase/migrations/20240906121523_fix_return_type_for_select_user_conversations.sql
@@ -1,0 +1,47 @@
+drop function if exists "public"."fetch_user_conversations"(p_user_id uuid);
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.fetch_user_conversations(p_user_id uuid)
+ RETURNS TABLE(id bigint, conversation_id bigint, user_id uuid, partner_id uuid, has_unread_messages boolean, partner_username text, partner_avatar text, message_text character varying, created_at timestamp with time zone, item_name text, item_image text)
+ LANGUAGE plpgsql
+AS $function$
+BEGIN
+  RETURN QUERY
+  SELECT DISTINCT ON (uc.conversation_id)
+    uc.id as id,
+    uc.conversation_id AS conversation_id,
+    uc.user_id AS user_id,
+    uc.partner_id AS partner_id,
+    uc.has_unread_messages AS has_unread_messages,
+    p.username AS partner_username,
+    p.avatar AS partner_avatar,
+    m.message_text AS message_text,
+    m.created_at AS created_at,
+    i.item_name AS item_name,
+    i."imageSrc" AS item_image
+  FROM
+    user_conversations uc
+  LEFT JOIN profiles p ON p.id = uc.partner_id
+  LEFT JOIN LATERAL (
+    SELECT
+        m.message_text,
+        m.created_at
+    FROM
+        messages m
+    WHERE
+        m.conversation_id = uc.conversation_id
+    ORDER BY
+        m.created_at DESC
+    LIMIT 1
+  ) m ON TRUE
+  LEFT JOIN items i ON i.id = uc.item_id
+  WHERE
+    uc.user_id = p_user_id 
+  ORDER BY
+    uc.conversation_id, m.created_at DESC;
+END;
+$function$
+;
+
+


### PR DESCRIPTION
# Description

**Closes #329**  

Bug fix for displaying a notification dot over any conversation card to a conversation with unread messages.

Extended tests to our messaging feature to avoid regression.

### Files changed

- `supabase/migrations/20240906121523_**.sql` - new migration file recreating the `fetch_user_conversations` function in our database to return the value of `has_unread_messages` in each conversation
- `ConversationsList.tsx` - added useEffect to update `notificationsList` local state when changes occur to `allConversations` in the wider context.
- `components/messaging/**.tsx` && `app/styles/messaging-styltes.css` - lifted some stylings and added `name` attributes to some elements for testability of the messaging functionality
- `messaging.cy.js`, `URLS.json` && `conversationsPage.js`- new testing suite for messaging feature

### UI changes

none - everything looks the same as before the bug was introduced

### Changes to Documentation

none

# Tests

New test suite verifies that:
 - users can see a notification dot for any conversations with unread messages
 - clicking a conversation removes the notification dot from it
 - a conversation can be marked as unread via the ellipsis button on the conversation card
 - a conversation can be deleted via the ellipsis button on the conversation card
 - a new message can be sent and will be immediately displayed on the page
