### PR TITLE
Fix broken "Roles and Responsibilities" link in the README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ next-env.d.ts
 # Sentry Config File
 .sentryclirc
 /test-results/
+
+# Cypress output
+cypress/screenshots/
+cypress/videos/

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Kindly is an open source project and we welcome anyone looking to get involved. 
 - [Best practice](https://github.com/enBloc-org/kindly/blob/dev/.github/BEST_PRACTICE.md)
 - [Testing](https://github.com/enBloc-org/kindly/blob/dev/.github/TESTING.md)
 - [Privacy](https://github.com/enBloc-org/kindly/blob/dev/PRIVACY.md)
-- [For details on the different roles you can take on](https://github.com/enBloc-org/kindly/blob/dev/GOVERNANCE.md)
+- [For details on the different roles you can take on](https://github.com/enBloc-org/kindly/blob/dev/.github/GOVERNANCE.md)
 
 ### Governance
 For details on different ways you can help maintaining Kindly please see our documentation on [governance](./.github/GOVERNANCE.md)


### PR DESCRIPTION
# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review on my code
- [x] I have made corresponding changes to the documentation (if any were needed)
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and previously existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description

**Relates #333  
The link in the README file under "For details on the different roles you can take on" should redirect users to the correct GOVERNANCE.md
### Files changed

Readme file


### Changes to Documentation

The link in the README file under 'For details on the different roles you can take on' 
has been updated to redirect to the correct GOVERNANCE.md file, located at
https://github.com/enBloc-org/kindly/blob/dev/.github/GOVERNANCE.md.
# Tests

I tested it manually, and it works.
