### PR TITLE
#328/feat: exclude issues in review from stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,6 +17,9 @@ jobs:
           days-before-close: -1 # this value will keep issues and prs from being closed
           include-only-assigned: true # issues in the backlog will not become stale
 
+          # exempt issues
+          exempt-issue-labels: 'in review'
+
           # stale and delete issues
           stale-issue-message: |
             🤖 meep morp! 


### PR DESCRIPTION
relates #328

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review on my code
- [x] I have made corresponding changes to the documentation (if any were needed)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works - not needed
- [x] New and previously existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Description

**Closes #328**  
I've added an exemption for the issues with the label 'in review'. To make it work, we would need to create a label 'in review' as following: 

1. Someone who has access to add new labels (probably @camelPhonso ) should go to [labels ](https://github.com/enBloc-org/kindly/labels) and click 'New label'
> ![image](https://github.com/user-attachments/assets/0db52d4e-ea93-410a-83c8-dafdf9651a65)
2. Add 'in review' label. (The label name should be exactly the same as in the stale.yml file)
> ![image](https://github.com/user-attachments/assets/4c0ffc8b-2acd-42bf-9444-61baddbd3343)
3. The label should be added ❗ manually to the issues that are in review. This can be done by anyone (at least I have access to add a label)
>![image](https://github.com/user-attachments/assets/f0b773d7-904f-44c6-8e3c-acf9281fccf9)

I understand that this solution may not be perfect as it requires people to manually add a label to prevent their issues from going stale during review. However, this is the only solution I have found so far - there is no way to create an exemption based on a column name.

### Files changed

> .github\workflows\stale.yml_
added `exempt-issue-labels: 'in review'` 

### UI changes
N/A

### Changes to Documentation
N/A

# Tests
N/A
I've tested this on my project and it worked. However, instead of waiting 7 days, I've tried with a trigger to apply changes immediately (`workflow_dispatch:` ). So this should work with the normal setup too. 