### PR TITLE
#382/fix edit item

### DIFF
--- a/app/(dashboard)/edit-item/[id]/page.tsx
+++ b/app/(dashboard)/edit-item/[id]/page.tsx
@@ -63,11 +63,13 @@ const EditItemPage = ({ params }: { params: { id: number } }) => {
     fetchItemData();
   }, []);
 
-  const onSubmit = async (data: PartialItem) => {
+  const onSubmit = async (data: PartialItem & { image?: object }) => {
+    const partialItem = Object.assign({}, data);
+    delete partialItem.image;
     const itemData: PartialItem = {
       id: params.id,
       imageSrc: imgSrc,
-      ...data,
+      ...partialItem,
     };
     try {
       const response = await upsertRow('items', itemData);

--- a/app/(dashboard)/edit-item/[id]/page.tsx
+++ b/app/(dashboard)/edit-item/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import ButtonRounded from '@/components/buttons/ButtonRounded';
-import { useForm } from 'react-hook-form';
+import { useForm, FormProvider } from 'react-hook-form';
 import { PartialItem } from '@/types/supabaseTypes';
 import UploadImageInput from '@/components/form/UploadImageInput';
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
@@ -13,14 +13,7 @@ const EditItemPage = ({ params }: { params: { id: number } }) => {
   const [imgSrc, setImageSrc] = useState('');
   const [generalError, setGeneralError] = useState('');
   const router = useRouter();
-
-  const {
-    register,
-    handleSubmit,
-    watch,
-    reset,
-    formState: { errors },
-  } = useForm({
+  const methods = useForm({
     defaultValues: {
       item_name: '',
       item_description: '',
@@ -34,6 +27,13 @@ const EditItemPage = ({ params }: { params: { id: number } }) => {
       postage_covered: false,
     },
   });
+  const {
+    register,
+    handleSubmit,
+    watch,
+    reset,
+    formState: { errors },
+  } = methods;
 
   useEffect(() => {
     const fetchItemData = async () => {
@@ -88,174 +88,180 @@ const EditItemPage = ({ params }: { params: { id: number } }) => {
   const isPickUpChecked = watch('collectible');
 
   return (
-    <div className='my-20 flex flex-col items-center gap-3'>
-      <h2 className='mb-10 font-bold'>Edit item</h2>
+    <FormProvider {...methods}>
+      <div className='my-20 flex flex-col items-center gap-3'>
+        <h2 className='mb-10 font-bold'>Edit item</h2>
 
-      <form
-        onSubmit={handleSubmit(onSubmit)}
-        className='flex flex-col items-center gap-5'
-      >
-        <label
-          htmlFor='item_name'
-          className='flex flex-col items-center gap-2 font-light'
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className='flex flex-col items-center gap-5'
         >
-          Item Name
-          <input
-            type='text'
-            className='input-text'
-            {...register('item_name', { required: 'This field is required' })}
-          />
-        </label>
-        <p className='error-message'>{errors.item_name?.message}</p>
-        <label
-          htmlFor='item_description'
-          className='flex flex-col items-center gap-1 font-light'
-        >
-          Description
-          <textarea
-            {...register('item_description')}
-            maxLength={200}
-            className='input-text'
-          />
-        </label>
-        <label
-          htmlFor='postcode'
-          className='flex flex-col items-center gap-1 font-light'
-        >
-          Postcode <span className='text-xs italic'>First half</span>
-          <input
-            type='text'
-            maxLength={5}
-            {...register('postcode', {
-              required: 'This field is required',
-              maxLength: {
-                value: 5,
-                message: 'Max length 5 characters',
-              },
-            })}
-            className='input-text w-24 text-center'
-          />
-        </label>
-        <p className='error-message'>{errors.postcode?.message}</p>
-        <div className='mt-2 flex items-center justify-center gap-5'>
           <label
-            htmlFor='condition'
+            htmlFor='item_name'
+            className='flex flex-col items-center gap-2 font-light'
+          >
+            Item Name
+            <input
+              type='text'
+              className='input-text'
+              {...register('item_name', { required: 'This field is required' })}
+            />
+          </label>
+          <p className='error-message'>{errors.item_name?.message}</p>
+          <label
+            htmlFor='item_description'
             className='flex flex-col items-center gap-1 font-light'
           >
-            Condition
-            <select
-              {...register('condition', { required: 'Required' })}
-              className='input-text '
-            >
-              <option value='' disabled hidden>
-                Select one
-              </option>
-              <option value={'Good'}>Good</option>
-              <option value={'Fair'}>Fair</option>
-              <option value={'Poor'}>Poor</option>
-              <option value={'New'}>New</option>
-            </select>
-            <p className='error-message'>{errors.condition?.message}</p>
+            Description
+            <textarea
+              {...register('item_description')}
+              maxLength={200}
+              className='input-text'
+            />
           </label>
           <label
-            htmlFor='item_type'
+            htmlFor='postcode'
             className='flex flex-col items-center gap-1 font-light'
           >
-            Categories
-            <select
-              {...register('item_type', { required: 'Required' })}
-              className='input-text '
-            >
-              <option value='' disabled hidden>
-                Select one
-              </option>
-              <option value={'clothing'}>Clothing</option>
-              <option value={'shoes'}>Shoes</option>
-              <option value={'toys'}>Toys</option>
-              <option value={'books'}>Books</option>
-              <option value={'household'}>Home</option>
-            </select>
-            <p className='error-message'>{errors.item_type?.message}</p>
+            Postcode <span className='text-xs italic'>First half</span>
+            <input
+              type='text'
+              maxLength={5}
+              {...register('postcode', {
+                required: 'This field is required',
+                maxLength: {
+                  value: 5,
+                  message: 'Max length 5 characters',
+                },
+              })}
+              className='input-text w-24 text-center'
+            />
           </label>
-        </div>
-        {(category === 'clothing' || category === 'shoes') && (
-          <div className='flex items-center justify-center gap-5'>
+          <p className='error-message'>{errors.postcode?.message}</p>
+          <div className='mt-2 flex items-center justify-center gap-5'>
             <label
-              htmlFor='size'
-              className='flex flex-col items-center gap-2 font-light'
+              htmlFor='condition'
+              className='flex flex-col items-center gap-1 font-light'
             >
-              Size
-              <input
-                type='text'
-                {...register('size')}
-                maxLength={30}
-                className='input-text h-11 w-24'
-              />
+              Condition
+              <select
+                {...register('condition', { required: 'Required' })}
+                className='input-text '
+              >
+                <option value='' disabled hidden>
+                  Select one
+                </option>
+                <option value={'Good'}>Good</option>
+                <option value={'Fair'}>Fair</option>
+                <option value={'Poor'}>Poor</option>
+                <option value={'New'}>New</option>
+              </select>
+              <p className='error-message'>{errors.condition?.message}</p>
             </label>
             <label
               htmlFor='item_type'
               className='flex flex-col items-center gap-1 font-light'
             >
-              Gender
-              <select {...register('item_subtype')} className='input-text '>
+              Categories
+              <select
+                {...register('item_type', { required: 'Required' })}
+                className='input-text '
+              >
                 <option value='' disabled hidden>
                   Select one
                 </option>
-                <option value={'women'}>Women</option>
-                <option value={'men'}>Men</option>
-                <option value={'girls'}>Girls</option>
-                <option value={'boys'}>Boys</option>
-                <option value={'unisex'}>Unisex</option>
+                <option value={'clothing'}>Clothing</option>
+                <option value={'shoes'}>Shoes</option>
+                <option value={'toys'}>Toys</option>
+                <option value={'books'}>Books</option>
+                <option value={'household'}>Home</option>
               </select>
-            </label>{' '}
+              <p className='error-message'>{errors.item_type?.message}</p>
+            </label>
           </div>
-        )}
-        {category === 'books' && (
-          <label
-            htmlFor='item_type'
-            className='flex flex-col items-center gap-1 font-light'
-          >
-            Age
-            <select {...register('item_subtype')} className='input-text '>
-              <option value={'adults'}>Adult</option>
-              <option value={'children'}>Children</option>
-            </select>
-          </label>
-        )}
-        <div className='mt-5 flex flex-col gap-3'>
-          <label className='flex items-center gap-2 font-light'>
-            <input type='checkbox' {...register('postable')} className='mr-2' />
-            Willing to Post
-          </label>
-          <label className='flex items-center gap-2 font-light'>
-            <input
-              type='checkbox'
-              {...register('collectible')}
-              className='mr-2'
-            />
-            Pick Up
-          </label>
-          <label className='flex items-center justify-center gap-2 font-light'>
-            <input
-              type='checkbox'
-              {...register('postage_covered')}
-              className='mr-2'
-            />
-            Postage Covered
-          </label>
-        </div>
-        {!isPickUpChecked && !isWillingToPostChecked && (
-          <p className='error-message'>Select at least one option </p>
-        )}
-        <UploadImageInput
-          setImageSrc={setImageSrc}
-          setError={setGeneralError}
-          imageType={'item'}
-        />
-        {generalError && <p className='error-message'>{generalError}</p>}
-        <ButtonRounded type='submit'>EDIT ITEM</ButtonRounded>
-      </form>
-    </div>
+          {(category === 'clothing' || category === 'shoes') && (
+            <div className='flex items-center justify-center gap-5'>
+              <label
+                htmlFor='size'
+                className='flex flex-col items-center gap-2 font-light'
+              >
+                Size
+                <input
+                  type='text'
+                  {...register('size')}
+                  maxLength={30}
+                  className='input-text h-11 w-24'
+                />
+              </label>
+              <label
+                htmlFor='item_type'
+                className='flex flex-col items-center gap-1 font-light'
+              >
+                Gender
+                <select {...register('item_subtype')} className='input-text '>
+                  <option value='' disabled hidden>
+                    Select one
+                  </option>
+                  <option value={'women'}>Women</option>
+                  <option value={'men'}>Men</option>
+                  <option value={'girls'}>Girls</option>
+                  <option value={'boys'}>Boys</option>
+                  <option value={'unisex'}>Unisex</option>
+                </select>
+              </label>{' '}
+            </div>
+          )}
+          {category === 'books' && (
+            <label
+              htmlFor='item_type'
+              className='flex flex-col items-center gap-1 font-light'
+            >
+              Age
+              <select {...register('item_subtype')} className='input-text '>
+                <option value={'adults'}>Adult</option>
+                <option value={'children'}>Children</option>
+              </select>
+            </label>
+          )}
+          <div className='mt-5 flex flex-col gap-3'>
+            <label className='flex items-center gap-2 font-light'>
+              <input
+                type='checkbox'
+                {...register('postable')}
+                className='mr-2'
+              />
+              Willing to Post
+            </label>
+            <label className='flex items-center gap-2 font-light'>
+              <input
+                type='checkbox'
+                {...register('collectible')}
+                className='mr-2'
+              />
+              Pick Up
+            </label>
+            <label className='flex items-center justify-center gap-2 font-light'>
+              <input
+                type='checkbox'
+                {...register('postage_covered')}
+                className='mr-2'
+              />
+              Postage Covered
+            </label>
+          </div>
+          {!isPickUpChecked && !isWillingToPostChecked && (
+            <p className='error-message'>Select at least one option </p>
+          )}
+          <UploadImageInput
+            setImageSrc={setImageSrc}
+            setError={setGeneralError}
+            imageType={'item'}
+          />
+          {generalError && <p className='error-message'>{generalError}</p>}
+          <ButtonRounded type='submit'>EDIT ITEM</ButtonRounded>
+        </form>
+      </div>
+    </FormProvider>
   );
 };
 export default EditItemPage;

--- a/cypress/e2e/item.cy.js
+++ b/cypress/e2e/item.cy.js
@@ -29,6 +29,12 @@ describe('Create and Delete item positive test Suite', () => {
     ProfilePage.itemCard(uniqueItemName).should('be.visible');
   });
 
+  it.only('User can edit an existing item', () => {
+    cy.visit(page.profile, { failOnStatusCode: false });
+    ProfilePage.editItemButton(data.itemName).click();
+    cy.url().should('include', '/edit-item/');
+  });
+
   it('User can delete the item', () => {
     cy.visit(page.profile, { failOnStatusCode: false });
 

--- a/cypress/e2e/item.cy.js
+++ b/cypress/e2e/item.cy.js
@@ -54,29 +54,9 @@ describe('Create and Delete item positive test Suite', () => {
     cy.log('Clicking confirm delete button');
     ProfilePage.ConfirmDeleteItemButton(uniqueItemName).click();
 
-    cy.log('Waiting for DELETE request');
-    cy.wait('@deleteItem').then((interception) => {
-      cy.log(`DELETE request intercepted: ${interception.request.url}`);
-      expect(interception.response.statusCode).to.eq(204);
-    });
-
-    const waitForItemRemoval = (itemName, maxAttempts = 20) => {
-      let attempts = 0;
-      const checkForItem = () => {
-        attempts++;
-        return cy.get('body').then(($body) => {
-          if (!$body.text().includes(itemName) || attempts >= maxAttempts) {
-            return;
-          }
-          cy.wait(500); // Wait 500ms between checks
-          checkForItem();
-        });
-      };
-      checkForItem();
-    };
-
-    waitForItemRemoval(uniqueItemName);
-
-    ProfilePage.itemCard(uniqueItemName).should('not.exist');
+    cy.url().should('include', '/profile');
+    cy.get('h2')
+      .contains(/successfully deleted/gi)
+      .should('be.visible');
   });
 });

--- a/cypress/e2e/item.cy.js
+++ b/cypress/e2e/item.cy.js
@@ -2,6 +2,7 @@ import AddItemPage from '../support/page_objects/addItemPage';
 import ProfilePage from '../support/page_objects/profilePage';
 import * as page from '../fixtures/URLs.json';
 import * as data from '../fixtures/inputData.json';
+import EditItemPage from '../support/page_objects/editItemPage';
 
 describe('Create and Delete item positive test Suite', () => {
   const uniqueItemName = `${data.itemName}_${Date.now()}`;
@@ -29,10 +30,17 @@ describe('Create and Delete item positive test Suite', () => {
     ProfilePage.itemCard(uniqueItemName).should('be.visible');
   });
 
-  it.only('User can edit an existing item', () => {
+  it('User can edit an existing item', () => {
     cy.visit(page.profile, { failOnStatusCode: false });
-    ProfilePage.editItemButton(data.itemName).click();
+    ProfilePage.editItemButton(uniqueItemName).click();
     cy.url().should('include', '/edit-item/');
+    EditItemPage.nameInput().should('have.value', uniqueItemName);
+    EditItemPage.descriptionInput()
+      .should('have.value', data.itemDescription)
+      .clear()
+      .type('new test value');
+    EditItemPage.editItemButton().click();
+    cy.url().should('include', '/edit-item/success');
   });
 
   it('User can delete the item', () => {

--- a/cypress/support/page_objects/addItemPage.js
+++ b/cypress/support/page_objects/addItemPage.js
@@ -1,46 +1,6 @@
-import BasePage from './basePage';
+import ItemForm from './itemForm';
 
-export class AddItemPage extends BasePage {
-  nameInput() {
-    return cy.get('input[name="item_name"]').should('be.visible');
-  }
-
-  descriptionInput() {
-    return cy.get('textarea[name="item_description"]').should('be.visible');
-  }
-
-  postCodeInput() {
-    return cy.get('input[name="postcode"]').should('be.visible');
-  }
-
-  conditionDropDown() {
-    return cy.get('select[name="condition"]').should('be.visible');
-  }
-
-  categoriesDropDown() {
-    return cy.get('select[name="item_type"]').should('be.visible');
-  }
-
-  sizeDropDown() {
-    return cy.get('select[name="size"]').should('be.visible');
-  }
-
-  genderDropDown() {
-    return cy.get('select[name="item_subtype"]').should('be.visible');
-  }
-
-  willingToPostCheckBox() {
-    return cy.get('input[name="postable"]').should('be.visible');
-  }
-
-  pickUpCheckBox() {
-    return cy.get('input[name="collectible"]').should('be.visible');
-  }
-
-  postageCoveredCheckBox() {
-    return cy.get('input[name="postage_covered"]').should('be.visible');
-  }
-
+export class AddItemPage extends ItemForm {
   uploadImageButton() {
     return cy.get('input[name="image"]').should('be.visible');
   }

--- a/cypress/support/page_objects/editItemPage.js
+++ b/cypress/support/page_objects/editItemPage.js
@@ -1,0 +1,12 @@
+import ItemForm from './itemForm';
+
+export class EditItemPage extends ItemForm {
+  editItemButton() {
+    return cy
+      .get('button')
+      .contains(/edit item/i)
+      .should('be.visible');
+  }
+}
+
+export default new EditItemPage();

--- a/cypress/support/page_objects/itemForm.js
+++ b/cypress/support/page_objects/itemForm.js
@@ -1,0 +1,43 @@
+import BasePage from './basePage';
+
+export default class ItemForm extends BasePage {
+  nameInput() {
+    return cy.get('input[name="item_name"]').should('be.visible');
+  }
+
+  descriptionInput() {
+    return cy.get('textarea[name="item_description"]').should('be.visible');
+  }
+
+  postCodeInput() {
+    return cy.get('input[name="postcode"]').should('be.visible');
+  }
+
+  conditionDropDown() {
+    return cy.get('select[name="condition"]').should('be.visible');
+  }
+
+  categoriesDropDown() {
+    return cy.get('select[name="item_type"]').should('be.visible');
+  }
+
+  sizeDropDown() {
+    return cy.get('select[name="size"]').should('be.visible');
+  }
+
+  genderDropDown() {
+    return cy.get('select[name="item_subtype"]').should('be.visible');
+  }
+
+  willingToPostCheckBox() {
+    return cy.get('input[name="postable"]').should('be.visible');
+  }
+
+  pickUpCheckBox() {
+    return cy.get('input[name="collectible"]').should('be.visible');
+  }
+
+  postageCoveredCheckBox() {
+    return cy.get('input[name="postage_covered"]').should('be.visible');
+  }
+}

--- a/cypress/support/page_objects/profilePage.js
+++ b/cypress/support/page_objects/profilePage.js
@@ -13,6 +13,16 @@ export class ProfilePage extends BasePage {
     return cy.contains('.card', itemName);
   }
 
+  editItemButton(itemName) {
+    return cy
+      .get('.card')
+      .contains(itemName)
+      .parents('li')
+      .find('a')
+      .contains(/edit item/gi)
+      .should('be.visible');
+  }
+
   deleteItemButton(itemName) {
     return cy
       .get('.card')


### PR DESCRIPTION
# Description

**Closes #382**
  
Clears the bug reported and extends our E2E tests to avoid regression.

The code changes also include:
-  a small refactoring of the original tests for faster performance and extended assertions
- a fix in our onSubmission for the item editing form that is affected by our image upload feature

I kept changes small because there's already an issue open to refactor the image upload (#334) but this probably needs a bigger restructuring of our composition in this part of the code to make that functionality leaner and avoid a messy form submission

### Files changed

- `edit-item/[id]/page.tsx` - wrap the form in `FormProvider` component and clone the object passed to `UpsertRow` within `onSubmit` to filter out `Image` property
- `cypress/support/page_objects/**` - add an `ItemForm` object that extends the `BasePage` and extend this for `EditItemPage` and `AddItemPage` to keep our assertions consistent across our testing of the different operations

### UI changes

n/a - everything looks the same

### Changes to Documentation

n/a

# Tests

- `item.cy.js` - added an `it` block to test editing an item before we delete it and refactored the block checking our 'delete' functionality to check for the success message we display on screen, avoiding the need for a recursive re-check of the page and coupling our test to our status communication to the user
