### PR TITLE
fix: added dafault image for avatar to avoid error

### DIFF
--- a/components/messaging/ConversationCard.tsx
+++ b/components/messaging/ConversationCard.tsx
@@ -39,7 +39,7 @@ const ConversationCard: React.FC<ConversationCardProps> = ({
   currentConversationId,
 }) => {
   const isBreakpoint = useMediaQuery(1000);
-  const [imgSrc, setImgSrc] = useState(partnerAvatar || '/default-profile.png');
+  const [imgSrc, setImgSrc] = useState(partnerAvatar ?? '/default-profile.png');
   const handleError = () => {
     setImgSrc('/default-profile.png');
   };

--- a/components/messaging/ConversationCard.tsx
+++ b/components/messaging/ConversationCard.tsx
@@ -39,7 +39,7 @@ const ConversationCard: React.FC<ConversationCardProps> = ({
   currentConversationId,
 }) => {
   const isBreakpoint = useMediaQuery(1000);
-  const [imgSrc, setImgSrc] = useState(partnerAvatar);
+  const [imgSrc, setImgSrc] = useState(partnerAvatar || '/default-profile.png');
   const handleError = () => {
     setImgSrc('/default-profile.png');
   };

--- a/supabase/migrations/20241128133000_schema_v2_start.sql
+++ b/supabase/migrations/20241128133000_schema_v2_start.sql
@@ -307,6 +307,9 @@ CREATE TABLE IF NOT EXISTS "public"."profiles" (
 
 ALTER TABLE "public"."profiles" OWNER TO "postgres";
 
+ALTER TABLE "public"."profiles"
+ALTER COLUMN "avatar" SET DEFAULT '/default-profile.png';
+
 COMMENT ON COLUMN "public"."profiles"."items_added" IS 'items the user has added';
 
 COMMENT ON COLUMN "public"."profiles"."reserved_items" IS 'items reserved by the user';

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -197,7 +197,7 @@ INSERT INTO "public"."conversations" ("id", "created_at") VALUES
 INSERT INTO "public"."profiles" ("id", "created_at", "email", "items_added", "reserved_items", "refugee", "image", "postcode", "username", "avatar") VALUES
 	('48f9db70-05f7-4a04-a34d-75ae8267c90b', '2024-06-16 13:26:37.960648+00', 'refugee+test.reshetniak@gmail.com', NULL, NULL, true, NULL, NULL, 'Test Refugee', 'https://undfcbmldjkujposixvn.supabase.co/storage/v1/object/public/images/48f9db70-05f7-4a04-a34d-75ae8267c90b/07995dac-6352-48fb-a061-c85b07560554'),
 	('cab97c8e-6704-4bb2-b3e8-a9cdaaf1be85', '2024-06-16 13:26:05.319866+00', 'donor+test.reshetniak@gmail.com', NULL, NULL, false, NULL, NULL, 'Test Donor', 'https://undfcbmldjkujposixvn.supabase.co/storage/v1/object/public/images/cab97c8e-6704-4bb2-b3e8-a9cdaaf1be85/04852b2e-da05-429e-acca-35eeb61d0b5f'),
-	('1dc06b29-0b93-46d8-a33b-fb6f80ee5263', '2024-07-08 10:36:10.438915+00', 'trafalgargirls@gmail.com', NULL, NULL, false, NULL, NULL, 'trafalgargirls', NULL);
+	('1dc06b29-0b93-46d8-a33b-fb6f80ee5263', '2024-07-08 10:36:10.438915+00', 'trafalgargirls@gmail.com', NULL, NULL, false, NULL, NULL, 'trafalgargirls', '/default-profile.png');
 
 
 --


### PR DESCRIPTION
# Description

Relates #394

This Pull Request fixes a runtime error that occurred when the partnerAvatar value was null in the ConversationCard component. The fix introduces a default profile image (/default-profile.png) to ensure that the application gracefully handles cases where a user has not set a profile picture.

No new dependencies were introduced.

### Files changed

- ConversationCard.tsx 
Updated the useState initialization for imgSrc to assign a default image (/default-profile.png) when partnerAvatar is null.

### UI changes

No visible UI changes as the fix ensures a fallback image is displayed when the profile picture is not set.

### Changes to Documentation

No updates to documentation were necessary for this change.

# Tests

The changes were tested locally, and all existing tests passed. Since this is a minor fix, no additional tests were added.
