### PR TITLE
#253/Items that have been uploaded more than 6 months before should be automatically deleted

### DIFF
--- a/supabase/migrations/20250324015132_add-pg_cron-job-to-delete-old-items.sql
+++ b/supabase/migrations/20250324015132_add-pg_cron-job-to-delete-old-items.sql
@@ -1,0 +1,10 @@
+create EXTENSION if not exists pg_cron with schema pg_catalog;
+
+grant usage on schema cron to postgres;
+grant all privileges on all tables in schema cron to postgres;
+
+select cron.schedule (
+    'monday-items-cleanup',
+    '0 11 * * 1', -- Monday at 11:00am (GMT)
+    $$ delete from public.items where created_at < NOW() - interval '6 months' $$
+);


### PR DESCRIPTION
# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review on my code
- [ ] I have made corresponding changes to the documentation (if any were needed)
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and previously existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Description

**Relates #[253](https://github.com/enBloc-org/kindly/issues/253)**
- Added pg_cron extension
- Created a recurring cron job to remove items older than 6 months based on the created_at field

This PR does not resolve questions:
- what happens if an item has been available for more than 6 months but there are active conversations relating to this issue?
- should the donor receive a notification that their item will be deleted if it is not given away soon ?
how would we notify them of this?

### Files changed
`20250324015132_add-pg_cron-job-to-delete-old-items` - added new migration

# Tests
Not sure is it possible or needed
