### PR TITLE
#427/conversation filter

### DIFF
--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -30,6 +30,8 @@ export default function SignUp({
       }
 
       setEmail(formData.get('email') as string);
+      const { profile } = await response.json();
+      return profile;
     } catch (error) {
       console.error(error);
     }

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -35,14 +35,17 @@ export async function POST(request: NextRequest) {
   }
 
   const userId = data && data.user?.id;
-  const { error: profileError } = await supabase.from('profiles').insert({
-    id: userId,
-    email: email,
-    username: username,
-    refugee: isRefugee,
-  });
+  const { data: profile, error: profileError } = await supabase
+    .from('profiles')
+    .insert({
+      id: userId,
+      email: email,
+      username: username,
+      refugee: isRefugee,
+    })
+    .select('*');
 
   if (profileError) console.error(profileError);
 
-  return NextResponse.next();
+  return NextResponse.json({ profile });
 }

--- a/components/messaging/ConversationList/ConversationList.stories.tsx
+++ b/components/messaging/ConversationList/ConversationList.stories.tsx
@@ -19,6 +19,8 @@ const dummyConversations = [
     item_name: 'Vintage Lamp',
     item_image: 'https://images.unsplash.com/photo-1507473885765-e6ed057f782c',
     partner_has_deleted: false,
+    is_donation_by_user: false,
+    item_donated_by: 'JaneDoe',
   },
   {
     id: 2,
@@ -34,6 +36,8 @@ const dummyConversations = [
     item_name: 'Wooden Chair',
     item_image: 'https://images.unsplash.com/photo-1503602642458-232111445657',
     partner_has_deleted: false,
+    is_donation_by_user: true,
+    item_donated_by: 'user123',
   },
   {
     id: 3,
@@ -49,6 +53,8 @@ const dummyConversations = [
     item_name: 'Ceramic Planter',
     item_image: 'https://images.unsplash.com/photo-1485955900006-10f4d324d411',
     partner_has_deleted: false,
+    is_donation_by_user: true,
+    item_donated_by: 'user123',
   },
   {
     id: 4,
@@ -64,6 +70,8 @@ const dummyConversations = [
     item_name: 'Vintage Record Player',
     item_image: 'https://images.unsplash.com/photo-1461360228754-6e81c478b882',
     partner_has_deleted: false,
+    is_donation_by_user: false,
+    item_donated_by: 'MichaelBrown',
   },
 ];
 

--- a/components/messaging/ConversationList/ConversationsList.tsx
+++ b/components/messaging/ConversationList/ConversationsList.tsx
@@ -84,7 +84,7 @@ const ConversationsList: React.FC = () => {
           ))
       ) : (
         <p className='pb-4 text-center font-light italic'>
-          You have no active conversations matching your selected filter.
+          {`You have no conversations as the ${selectedFilter.toLowerCase()}`}
         </p>
       )}
     </div>

--- a/components/messaging/ConversationList/ConversationsList.tsx
+++ b/components/messaging/ConversationList/ConversationsList.tsx
@@ -58,24 +58,30 @@ const ConversationsList: React.FC = () => {
         setSelectedFilter={setSelectedFilter}
       />
       {allConversations.length > 0 ? (
-        allConversations.map((conversation) => (
-          <div key={`${conversation.id}`}>
-            <ConversationCard
-              conversationId={conversation.conversation_id}
-              messageTimestamp={conversation.created_at}
-              messageText={conversation.message_text}
-              partnerUsername={conversation.partner_username}
-              itemImage={conversation.item_image}
-              clickHandler={() =>
-                updateOpenConversation(conversation.conversation_id)
-              }
-              notificationList={notificationList}
-              currentConversationId={
-                currentConversation?.conversation_id as number
-              }
-            />
-          </div>
-        ))
+        allConversations
+          .filter((conversation) =>
+            selectedFilter === ConversationFilters.GIVER
+              ? conversation.is_donation_by_user
+              : !conversation.is_donation_by_user
+          )
+          .map((conversation) => (
+            <div key={`${conversation.id}`}>
+              <ConversationCard
+                conversationId={conversation.conversation_id}
+                messageTimestamp={conversation.created_at}
+                messageText={conversation.message_text}
+                partnerUsername={conversation.partner_username}
+                itemImage={conversation.item_image}
+                clickHandler={() =>
+                  updateOpenConversation(conversation.conversation_id)
+                }
+                notificationList={notificationList}
+                currentConversationId={
+                  currentConversation?.conversation_id as number
+                }
+              />
+            </div>
+          ))
       ) : (
         <p className='pb-4 text-center font-light italic'>
           You have no active conversations.

--- a/components/messaging/ConversationList/ConversationsList.tsx
+++ b/components/messaging/ConversationList/ConversationsList.tsx
@@ -84,7 +84,7 @@ const ConversationsList: React.FC = () => {
           ))
       ) : (
         <p className='pb-4 text-center font-light italic'>
-          You have no active conversations.
+          You have no active conversations matching your selected filter.
         </p>
       )}
     </div>

--- a/supabase/migrations/20250705124725_refactor_fetch_user_conversations.sql
+++ b/supabase/migrations/20250705124725_refactor_fetch_user_conversations.sql
@@ -1,18 +1,19 @@
-CREATE or REPLACE function fetch_user_conversations()
+DROP FUNCTION IF EXISTS fetch_user_conversations(uuid);
+CREATE or REPLACE function fetch_user_conversations(p_user_id uuid)
 RETURNS TABLE (
-  id UUID,
-  conversation_id UUID,
+  id BIGINT,
+  conversation_id BIGINT,
   user_id UUID,
   partner_id UUID,
   has_unread_messages BOOLEAN,
   partner_has_deleted BOOLEAN,
   partner_username TEXT,
   partner_avatar TEXT,
-  message_text TEXT,
-  created_at TIMESTAMP,
+  message_text VARCHAR,
+  created_at TIMESTAMPTZ,
   item_name TEXT,
   item_image TEXT,
-  isDonatedByUser BOOLEAN
+  is_donation_by_user BOOLEAN
 ) LANGUAGE plpgsql AS $$
 
 BEGIN
@@ -32,7 +33,7 @@ BEGIN
       m.created_at AS created_at,
       i.item_name AS item_name,
       i."imageSrc" AS item_image,
-      (i.donated_by = uc.user_id) AS isDonatedByUSer
+      (i.donated_by = uc.user_id) AS is_donation_by_user
     FROM
       user_conversations uc
     LEFT JOIN profiles p ON p.id = uc.partner_id

--- a/supabase/migrations/20250705124725_refactor_fetch_user_conversations.sql
+++ b/supabase/migrations/20250705124725_refactor_fetch_user_conversations.sql
@@ -1,0 +1,58 @@
+CREATE or REPLACE function fetch_user_conversations()
+RETURNS TABLE (
+  id UUID,
+  conversation_id UUID,
+  user_id UUID,
+  partner_id UUID,
+  has_unread_messages BOOLEAN,
+  partner_has_deleted BOOLEAN,
+  partner_username TEXT,
+  partner_avatar TEXT,
+  message_text TEXT,
+  created_at TIMESTAMP,
+  item_name TEXT,
+  item_image TEXT,
+  isDonatedByUser BOOLEAN
+) LANGUAGE plpgsql AS $$
+
+BEGIN
+  RETURN QUERY
+  SELECT *
+  FROM (
+    SELECT DISTINCT ON (uc.conversation_id)
+      uc.id as id,
+      uc.conversation_id AS conversation_id,
+      uc.user_id AS user_id,
+      uc.partner_id AS partner_id,
+      uc.has_unread_messages AS has_unread_messages,
+      uc.partner_has_deleted AS partner_has_deleted,
+      p.username AS partner_username,
+      p.avatar AS partner_avatar,
+      m.message_text AS message_text,
+      m.created_at AS created_at,
+      i.item_name AS item_name,
+      i."imageSrc" AS item_image,
+      (i.donated_by = uc.user_id) AS isDonatedByUSer
+    FROM
+      user_conversations uc
+    LEFT JOIN profiles p ON p.id = uc.partner_id
+    LEFT JOIN LATERAL (
+      SELECT
+          m.message_text,
+          m.created_at
+      FROM
+          messages m
+      WHERE
+          m.conversation_id = uc.conversation_id
+      ORDER BY
+          m.created_at DESC
+      LIMIT 1
+    ) m ON TRUE
+    LEFT JOIN items i ON i.id = uc.item_id
+    WHERE
+      uc.user_id = p_user_id
+  ) sub
+  ORDER BY
+    sub.created_at DESC;
+END;
+$$;

--- a/supabase/migrations/20250712162705_update_profile_message_and_item_function.sql
+++ b/supabase/migrations/20250712162705_update_profile_message_and_item_function.sql
@@ -1,0 +1,29 @@
+DROP FUNCTION IF EXISTS fetch_profile_message_and_item(bigint, bigint, uuid);
+CREATE or REPLACE function fetch_profile_message_and_item(uc_conversation_id bigint, uc_item_id bigint, uc_partner_id uuid)
+RETURNS TABLE (
+  avatar TEXT,
+  message_text VARCHAR,
+  created_at TIMESTAMPTZ,
+  item_name TEXT,
+  is_donation_by_user BOOLEAN
+) LANGUAGE plpgsql AS $$
+
+BEGIN
+    RETURN QUERY
+    SELECT
+        p.avatar,
+        m.message_text,
+        m.created_at,
+        i.item_name,
+        (i.donated_by != uc_partner_id) AS is_donation_by_user
+    FROM
+        profiles p
+    LEFT JOIN messages m ON m.conversation_id = uc_conversation_id
+    LEFT JOIN items i ON i.id = uc_item_id
+    WHERE
+        p.id = uc_partner_id
+    ORDER BY
+        m.created_at DESC
+    LIMIT 1;
+END;
+$$;

--- a/supabase/models/messaging/selectConversationCardDetails.ts
+++ b/supabase/models/messaging/selectConversationCardDetails.ts
@@ -35,6 +35,7 @@ const selectConversationCardDetails = async (
       created_at: info.created_at,
       item_name: info.item_name,
       item_image: info.item_image,
+      is_donation_by_user: info.is_donation_by_user,
     };
 
     return singleConversation;

--- a/types/messagingTypes.ts
+++ b/types/messagingTypes.ts
@@ -50,7 +50,6 @@ export type ConversationCardType = {
   item_image: string;
   partner_has_deleted: boolean;
   is_donation_by_user: boolean;
-  item_donated_by: string;
 };
 
 export const ConversationFilters = {

--- a/types/messagingTypes.ts
+++ b/types/messagingTypes.ts
@@ -49,6 +49,8 @@ export type ConversationCardType = {
   item_name: string;
   item_image: string;
   partner_has_deleted: boolean;
+  is_donation_by_user: boolean;
+  item_donated_by: string;
 };
 
 export const ConversationFilters = {

--- a/types/types.gen.ts
+++ b/types/types.gen.ts
@@ -330,6 +330,7 @@ export type Database = {
           created_at: string
           item_name: string
           item_image: string
+          is_donation_by_user: boolean
         }[]
       }
     }

--- a/types/types.gen.ts
+++ b/types/types.gen.ts
@@ -304,6 +304,7 @@ export type Database = {
           message_text: string
           created_at: string
           item_name: string
+          is_donation_by_user: boolean
         }[]
       }
       fetch_recently_added_items: {


### PR DESCRIPTION
# Description

Closes #427 

This pr adds a migration file to update one of the supabase functions so that it returns a calculated boolean to be used when filtering the conversations displayed.

This process keeps the calculation in the server side, happening only when we set the context for our app, and let's us adjust what is displayed with a simple ternary comparing the returned boolean and the selected filter.

### Files changed

 - `migrations/**` - new migration file adjusts the return value of `fetch_user_conversations`
 - `ConversationsList.tsx` - conditionally filters the displayed list of conversations based on the selected filter
 - `types/messagingTypes.ts` - extends the type for `ConversationCardType` to match `fetch_user_conversations`

### UI changes

The UI is the same - just added the logic to give functionality to the sliding filter button

Filtering for 'giver'
<img width="492" alt="Screenshot 2025-07-05 at 15 07 29" src="https://github.com/user-attachments/assets/59bf5833-cfff-429a-8bdf-3673cb3ce53d" />

Filtering for 'receiver'
<img width="494" alt="Screenshot 2025-07-05 at 15 07 47" src="https://github.com/user-attachments/assets/192fe51b-90e9-4199-bb95-92a64bd61b2c" />


### Changes to Documentation

No changes that required updates in documentation

# Tests

I didn't even...