### PR TITLE
#430/conversation header

### DIFF
--- a/.github/workflows/supabase-ci.yml
+++ b/.github/workflows/supabase-ci.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: latest
+          version: 2.24.3
 
       - name: Start Supabase local development setup
         run: supabase start
@@ -21,7 +21,7 @@ jobs:
       - name: Verify generated types are checked in
         run: |
           supabase gen types typescript --local > types/types.gen.ts
-          if ! git diff --ignore-space-at-eol --exit-code --quiet types/types.gen.ts; then
+          if ! git diff --ignore-space-at-eol --exit-code --quiet HEAD.. types/types.gen.ts; then
             echo "Detected uncommitted changes after build. See status below:"
             git diff
             exit 1

--- a/components/icons/EllipsisIcon.tsx
+++ b/components/icons/EllipsisIcon.tsx
@@ -17,9 +17,9 @@ const EllipsisIcon: React.FC<EllipsisIconProps> = ({ width, height }) => {
         strokeLinejoin='round'
         strokeWidth='1.5'
       >
-        <circle cx='2.5' cy='8' r='.75' />
+        <circle cx='8' cy='2.5' r='.75' />
         <circle cx='8' cy='8' r='.75' />
-        <circle cx='13.5' cy='8' r='.75' />
+        <circle cx='8' cy='13.5' r='.75' />
       </g>
     </svg>
   );

--- a/components/menus/EllipsisMenu.stories.tsx
+++ b/components/menus/EllipsisMenu.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import EllipsisMenu from './EllipsisMenu';
+
+const meta: Meta<typeof EllipsisMenu> = {
+  title: 'General/EllipsisMenu',
+  component: EllipsisMenu,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DefaultEllipsisMenu: Story = {
+  args: {
+    menuOptions: [
+      {
+        buttonMessage: 'Chat rules',
+        clickHandler: fn(),
+      },
+      {
+        buttonMessage: 'Report user',
+        clickHandler: fn(),
+      },
+      {
+        buttonMessage: 'Delete chat',
+        clickHandler: fn(),
+      },
+    ],
+  },
+};

--- a/components/menus/EllipsisMenu.tsx
+++ b/components/menus/EllipsisMenu.tsx
@@ -20,30 +20,35 @@ const EllipsisMenu: React.FC<EllipsisMenuType> = ({ menuOptions }) => {
   };
 
   return (
-    <>
+    <div className='relative'>
       <button
         onClick={toggleMenuClickHandler}
-        className='rounded-md p-[.05rem] hover:bg-gray-200 hover:bg-opacity-50'
+        className='rounded-md p-[.05rem]'
         name='ellipsis-button'
       >
         <EllipsisIcon width={25} height={25} />
       </button>
       {isMenuOpen && (
-        <div className='absolute right-0 top-10 z-20 flex w-40 flex-col gap-2 rounded-lg bg-secondaryGreen py-2 shadow-md'>
-          {menuOptions.map((option) => {
+        <div className='absolute right-0 top-10 z-20 flex w-40 flex-col gap-2 rounded-md bg-monoY py-2 shadow-md'>
+          {menuOptions.map((option, index) => {
             return (
-              <button
-                key={option.buttonMessage}
-                className='py-[.15rem] text-sm hover:bg-gray-200 hover:bg-opacity-50'
-                onClick={option.clickHandler}
-              >
-                {option.buttonMessage}
-              </button>
+              <>
+                <button
+                  key={option.buttonMessage}
+                  className='mx-5 py-[.15rem] text-sm hover:bg-gray-200 hover:bg-opacity-50'
+                  onClick={option.clickHandler}
+                >
+                  {option.buttonMessage}
+                </button>
+                {index !== menuOptions.length - 1 && (
+                  <hr className='mx-5 border-primaryOrange' />
+                )}
+              </>
             );
           })}
         </div>
       )}
-    </>
+    </div>
   );
 };
 

--- a/components/messaging/ConversationHeader/ConversationHeader.stories.tsx
+++ b/components/messaging/ConversationHeader/ConversationHeader.stories.tsx
@@ -2,10 +2,18 @@ import type { Meta, StoryObj } from '@storybook/react';
 import ConversationHeader from './ConversationHeader';
 import { within, userEvent, waitFor } from '@storybook/test';
 import { expect } from '@storybook/jest';
+import ConversationContextProvider from '@/context/conversationContext';
 
 const meta: Meta<typeof ConversationHeader> = {
   title: 'Messaging/ConversationHeader',
   component: ConversationHeader,
+  decorators: [
+    (Story) => (
+      <ConversationContextProvider>
+        <Story />
+      </ConversationContextProvider>
+    ),
+  ],
 };
 
 export default meta;

--- a/components/messaging/ConversationHeader/ConversationHeader.stories.tsx
+++ b/components/messaging/ConversationHeader/ConversationHeader.stories.tsx
@@ -28,9 +28,6 @@ export const DefaultConversationHeader: Story = {
     await step('Open ellipsis menu', async () => {
       await userEvent.click(canvas.getByRole('button'));
     });
-    await waitFor(() => expect(canvas.getByText(/do things/i)).toBeVisible());
-    await waitFor(() =>
-      expect(canvas.getByText(/show chat rules/i)).toBeVisible()
-    );
+    await waitFor(() => expect(canvas.getByText(/chat rules/gi)).toBeVisible());
   },
 };

--- a/components/messaging/ConversationHeader/ConversationHeader.stories.tsx
+++ b/components/messaging/ConversationHeader/ConversationHeader.stories.tsx
@@ -1,7 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import ConversationHeader from './ConversationHeader';
-import { within, userEvent, waitFor } from '@storybook/test';
-import { expect } from '@storybook/jest';
 import ConversationContextProvider from '@/context/conversationContext';
 
 const meta: Meta<typeof ConversationHeader> = {
@@ -22,12 +20,5 @@ type Story = StoryObj<typeof meta>;
 export const DefaultConversationHeader: Story = {
   args: {
     partnerName: 'Maria Melnyk',
-  },
-  play: async ({ canvasElement, step }) => {
-    const canvas = within(canvasElement);
-    await step('Open ellipsis menu', async () => {
-      await userEvent.click(canvas.getByRole('button'));
-    });
-    await waitFor(() => expect(canvas.getByText(/chat rules/gi)).toBeVisible());
   },
 };

--- a/components/messaging/ConversationHeader/ConversationHeader.stories.tsx
+++ b/components/messaging/ConversationHeader/ConversationHeader.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ConversationHeader from './ConversationHeader';
+import { within, userEvent, waitFor } from '@storybook/test';
+import { expect } from '@storybook/jest';
+
+const meta: Meta<typeof ConversationHeader> = {
+  title: 'Messaging/ConversationHeader',
+  component: ConversationHeader,
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DefaultConversationHeader: Story = {
+  args: {
+    partnerName: 'Maria Melnyk',
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step('Open ellipsis menu', async () => {
+      await userEvent.click(canvas.getByRole('button'));
+    });
+    await waitFor(() => expect(canvas.getByText(/do things/i)).toBeVisible());
+    await waitFor(() =>
+      expect(canvas.getByText(/show chat rules/i)).toBeVisible()
+    );
+  },
+};

--- a/components/messaging/ConversationHeader/ConversationHeader.tsx
+++ b/components/messaging/ConversationHeader/ConversationHeader.tsx
@@ -12,12 +12,17 @@ export default function ConversationHeader({
 
   const conversationOptions = [
     {
-      buttonMessage: 'do things',
+      buttonMessage: 'Chat rules',
       clickHandler: (e: React.MouseEvent<HTMLButtonElement>) =>
         console.log(`clicked at ${e.timeStamp}`),
     },
     {
-      buttonMessage: 'show chat rules',
+      buttonMessage: 'Report user',
+      clickHandler: (e: React.MouseEvent<HTMLButtonElement>) =>
+        console.log(`clicked at ${e.timeStamp}`),
+    },
+    {
+      buttonMessage: 'Delete chat',
       clickHandler: (e: React.MouseEvent<HTMLButtonElement>) =>
         console.log(`clicked at ${e.timeStamp}`),
     },

--- a/components/messaging/ConversationHeader/ConversationHeader.tsx
+++ b/components/messaging/ConversationHeader/ConversationHeader.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import BackButton from '@/components/buttons/BackButton';
 import EllipsisMenu from '@/components/menus/EllipsisMenu';
+import { useConversationContext } from '@/context/conversationContext';
 
 export default function ConversationHeader({
   partnerName,
 }: {
   partnerName: string;
 }) {
+  const { dispatch } = useConversationContext();
+
   const conversationOptions = [
     {
       buttonMessage: 'do things',
@@ -20,9 +22,33 @@ export default function ConversationHeader({
         console.log(`clicked at ${e.timeStamp}`),
     },
   ];
+
+  const toggleDisplay = () => {
+    dispatch({
+      type: 'SET_SHOW_CONVERSATIONS_LIST',
+      payload: true,
+    });
+  };
+
   return (
     <div className='flex items-center justify-between p-2'>
-      <BackButton />
+      <button onClick={toggleDisplay}>
+        <svg
+          xmlns='http://www.w3.org/2000/svg'
+          width='40'
+          height='40'
+          viewBox='0 0 512 512'
+        >
+          <path
+            fill='none'
+            stroke='currentColor'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+            strokeWidth='48'
+            d='M244 400L100 256l144-144M120 256h292'
+          />
+        </svg>
+      </button>
       <p className='text-xl font-bold'>{partnerName}</p>
       <EllipsisMenu menuOptions={conversationOptions} />
     </div>

--- a/components/messaging/ConversationHeader/ConversationHeader.tsx
+++ b/components/messaging/ConversationHeader/ConversationHeader.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import BackButton from '@/components/buttons/BackButton';
+import EllipsisMenu from '@/components/menus/EllipsisMenu';
+
+export default function ConversationHeader({
+  partnerName,
+}: {
+  partnerName: string;
+}) {
+  const conversationOptions = [
+    {
+      buttonMessage: 'do things',
+      clickHandler: (e: React.MouseEvent<HTMLButtonElement>) =>
+        console.log(`clicked at ${e.timeStamp}`),
+    },
+    {
+      buttonMessage: 'show chat rules',
+      clickHandler: (e: React.MouseEvent<HTMLButtonElement>) =>
+        console.log(`clicked at ${e.timeStamp}`),
+    },
+  ];
+  return (
+    <div className='flex items-center justify-between p-2'>
+      <BackButton />
+      <p className='text-xl font-bold'>{partnerName}</p>
+      <EllipsisMenu menuOptions={conversationOptions} />
+    </div>
+  );
+}

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../utils/formatTimeStamp';
 import newClient from '@/supabase/utils/newClient';
 import SystemMessageCard from './SystemMessageCard';
+import ConversationHeader from './ConversationHeader/ConversationHeader';
 
 const CurrentConversation: React.FC = () => {
   const {
@@ -130,6 +131,9 @@ const CurrentConversation: React.FC = () => {
 
   return (
     <div className='message-card-container flex flex-1 flex-col justify-between bg-[#fafaf9] shadow-inner'>
+      <ConversationHeader
+        partnerName={currentConversation?.partner_username as string}
+      />
       <div
         className='relative flex h-full flex-col-reverse overflow-y-auto overflow-x-hidden'
         ref={chatWindowRef}

--- a/components/messaging/CurrentConversation.tsx
+++ b/components/messaging/CurrentConversation.tsx
@@ -14,6 +14,7 @@ import {
 import newClient from '@/supabase/utils/newClient';
 import SystemMessageCard from './SystemMessageCard';
 import ConversationHeader from './ConversationHeader/ConversationHeader';
+import useMediaQuery from '../hooks/useMediaQuery';
 
 const CurrentConversation: React.FC = () => {
   const {
@@ -26,6 +27,7 @@ const CurrentConversation: React.FC = () => {
   const [systemUser, setSystemUser] = useState<string | undefined>(undefined);
   const chatWindowRef = useRef<HTMLDivElement>(null);
   const supabase = newClient();
+  const isBreakPoint = useMediaQuery(1024);
 
   useEffect(() => {
     const getSystemUser = async () => {
@@ -131,9 +133,11 @@ const CurrentConversation: React.FC = () => {
 
   return (
     <div className='message-card-container flex flex-1 flex-col justify-between bg-[#fafaf9] shadow-inner'>
-      <ConversationHeader
-        partnerName={currentConversation?.partner_username as string}
-      />
+      {isBreakPoint && (
+        <ConversationHeader
+          partnerName={currentConversation?.partner_username as string}
+        />
+      )}
       <div
         className='relative flex h-full flex-col-reverse overflow-y-auto overflow-x-hidden'
         ref={chatWindowRef}


### PR DESCRIPTION
# Description

closes #430 
relates #431 

Creates a new component for the header of conversations with the existing `EllipsisMenu.tsx` adapted to the new figma design (this component was previously only used inside the `ConversationCard` component so I just re-styled it slightly).

**Note**: I left the functionality in the ellipsis menu for whoever takes issue #431 but did most of the styling. In the figma each option in the drop-down menu has an icon in the description but I left that out for now. Ideally, if there's a way we can get those as unicode or something we could display them in the string part of the expected arguments for the `EllipsisMenu`, otherwise it will require some refactoring.

### Files changed

- `ConversationHeader/` - new component and stories file
- `EllipsisIcon.tsx`, `EllipsisMenu.tsx` && `EllipsisMenu.stories.tsx` - restyled the component and added it to our component library
- `CurrentConversation.tsx` - displaying the new header conditionally on breakpoint

### UI changes

<img width="514" height="895" alt="new conversation header displayed" src="https://github.com/user-attachments/assets/288ea3af-5037-476d-8d5f-c6110fe67ff4" />


### Changes to Documentation

No documentation updates needed. Expanded the component library with new story files.

# Tests

Added some action tests in storybook, left e2e as is
